### PR TITLE
inline pinoLambdaDestination

### DIFF
--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -6,8 +6,6 @@ export interface SlackTransportOptions {
 }
 
 const options: Partial<SlackTransportOptions> = { webhookUrl: process.env.SLACK_WEBHOOK_URL };
-const destination = pinoLambdaDestination();
-
 const optionsOrStream: LoggerOptions = {
   transport: {
     targets: [
@@ -17,6 +15,8 @@ const optionsOrStream: LoggerOptions = {
   },
 };
 export const logger =
-  process.env.IS_LAMBDA === 'true' ? pino(destination) : pino(process.env.NEXT_RUNTIME ? {} : optionsOrStream);
+  process.env.IS_LAMBDA === 'true'
+    ? pino(pinoLambdaDestination())
+    : pino(process.env.NEXT_RUNTIME ? {} : optionsOrStream);
 
 export { lambdaRequestTracker } from 'pino-lambda';


### PR DESCRIPTION
## Description

## Description

vercel is failing with `The edge runtime does not support Node.js 'stream' module.`

## External Resources

https://vercel.com/adsviewer-projects/prod-webapp/logs?slug=app-future&slug=en-US&slug=adsviewer-projects&slug=prod-webapp&slug=logs&page=1&timeline=past30Minutes&startDate=1715952618740&endDate=1715954418740&selectedLogId=1715954418740801885962553757&selectedLogTimestamp=1715954418740&forceEndDate=1715954418740
