### PR TITLE
fix logger in nextjs

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -4,6 +4,9 @@ const withNextIntl = createNextIntlPlugin();
 
 /** @type {import('next').NextConfig} */
 const config = {
+  experimental: {
+    serverComponentsExternalPackages: ['pino'],
+  },
   reactStrictMode: true,
   rewrites: async () => {
     return {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,6 +36,7 @@
     "lucide-react": "^0.376.0",
     "next": "^14.2.3",
     "next-intl": "^3.11.3",
+    "pino": "^9.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.51.3",

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -31,6 +31,6 @@ export const logger =
           formatter: new CustomLogFormatter(),
         }),
       )
-    : pino(process.env.NEXT_RUNTIME ? {} : optionsOrStream);
+    : pino(optionsOrStream);
 
 export { lambdaRequestTracker } from 'pino-lambda';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,9 @@ importers:
       next-intl:
         specifier: ^3.11.3
         version: 3.12.0(next@14.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.76.0))(react@18.3.1)
+      pino:
+        specifier: ^9.0.0
+        version: 9.0.0
       react:
         specifier: ^18.3.1
         version: 18.3.1


### PR DESCRIPTION
## Description

web2 would need to install pino and add the experimental configuration at the next.config.mjs

jfyi with pino if you want to log an object you should put infront. It won't make any sense with pretty, but in prod we are using json based output and the object will be embedded in the json

for examle `logger.info({ hello: 'world' }, 'Hello, world!');` will become: `{"level":30,"time":1716188778833,"hello":"world","msg":"Hello, world!"}`, but `logger.info('Hello, world!', { hello: 'world' });` will skip the object entirely, outputting: `{"level":30,"time":1716188824039,"msg":"Hello, world!"}`
