### PR TITLE
revoke fb connection when token is expired

### DIFF
--- a/apps/server/src/schema/integrations/integration-types.ts
+++ b/apps/server/src/schema/integrations/integration-types.ts
@@ -16,6 +16,7 @@ export enum IntegrationStatusEnum {
 export const ShouldConnectIntegrationStatuses = [
   IntegrationStatusEnum.NotConnected,
   IntegrationStatusEnum.Expired,
+  IntegrationStatusEnum.Connected,
   IntegrationStatusEnum.Revoked,
 ];
 

--- a/apps/web/src/app/[locale]/(logged-in)/settings/integrations/card.tsx
+++ b/apps/web/src/app/[locale]/(logged-in)/settings/integrations/card.tsx
@@ -9,7 +9,8 @@ import { toast } from 'react-toastify';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import * as changeCase from 'change-case';
-import { type SettingsChannelsQuery, IntegrationStatus } from '@/graphql/generated/schema-server';
+import { metaErrorValidatingAccessToken } from '@repo/utils';
+import { IntegrationStatus, type SettingsChannelsQuery } from '@/graphql/generated/schema-server';
 import { integrationTypeMap, type UnwrapArray } from '@/util/types';
 import { deAuthIntegration } from '@/app/[locale]/(logged-in)/settings/integrations/actions';
 
@@ -49,9 +50,14 @@ export default function Card({
           setRedirectUrl(resp.data);
           break;
         case 'BaseError':
-        case 'MetaError':
-          toast.error(resp.message);
+        case 'MetaError': {
+          if (resp.message === metaErrorValidatingAccessToken) {
+            setCardStatus(IntegrationStatus.Revoked);
+          } else {
+            toast.error(resp.message);
+          }
           break;
+        }
         default:
           break;
       }

--- a/packages/utils/src/error-messages.ts
+++ b/packages/utils/src/error-messages.ts
@@ -1,0 +1,2 @@
+export const metaErrorValidatingAccessToken =
+  'Error validating access token: The session has been invalidated because the user changed their password or Facebook has changed the session for security reasons.';

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,5 +1,6 @@
 export * from './env-helper';
 export * from './error-helper';
+export * from './error-messages';
 export * from './password-helper';
 export * from './fire-and-forget';
 export * from './date-utils';


### PR DESCRIPTION
## Description

Occasionally fb will expire the tokens before the expiry date. In these case the user was not able to revoke (and the recconnect) the channel, becuase on revoke an error was thrown. 