### PR TITLE
add insightDatapoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
           pnpm install
           pnpm --filter=database generate
 
+      - name: Test
+        run: pnpm test
+
       - name: Lint
         run: pnpm lint
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 pnpm --filter=server codegen
+pnpm test
 git add apps/server/src/schema/generated/*
 git add apps/web/src/graphql/generated/*
 pnpm lint-staged

--- a/apps/server/src/schema/generated/schema.graphql
+++ b/apps/server/src/schema/generated/schema.graphql
@@ -329,6 +329,17 @@ type InsightsDatapoints {
   spend: Int!
 }
 
+input InsightsDatapointsInput {
+  adAccountId: String
+  adId: String
+  dateFrom: Date!
+  dateTo: Date!
+  device: DeviceEnum
+  interval: InsightsInterval!
+  position: InsightsPosition
+  publisher: PublisherEnum
+}
+
 enum InsightsInterval {
   day
   week
@@ -473,6 +484,7 @@ enum PublisherEnum {
 
 type Query {
   generateGoogleAuthUrl(state: String!): GenerateGoogleAuthUrlResponse!
+  insightDatapoints(args: InsightsDatapointsInput!): [InsightsDatapoints!]!
   insights(filter: FilterInsightsInput!): GroupedInsight!
   integrations(type: IntegrationType): [Integration!]!
   lastThreeMonthsAds: [Ad!]!

--- a/apps/server/src/schema/integrations/integration-types.ts
+++ b/apps/server/src/schema/integrations/integration-types.ts
@@ -242,4 +242,18 @@ export const FilterInsightsInput = builder.inputType('FilterInsightsInput', {
   }),
 });
 
+export const InsightsDatapointsInput = builder.inputType('InsightsDatapointsInput', {
+  fields: (t) => ({
+    adAccountId: t.string({ required: false }),
+    adId: t.string({ required: false }),
+    dateFrom: t.field({ type: 'Date', required: true }),
+    dateTo: t.field({ type: 'Date', required: true }),
+    device: t.field({ type: DeviceEnumDto, required: false }),
+    interval: t.field({ type: InsightsIntervalDto, required: true }),
+    position: t.field({ type: InsightsPositionDto, required: false }),
+    publisher: t.field({ type: PublisherEnumDto, required: false }),
+  }),
+});
+
 export type FilterInsightsInputType = typeof FilterInsightsInput.$inferInput;
+export type InsightsDatapointsInputType = typeof InsightsDatapointsInput.$inferInput;

--- a/apps/server/test/utils/insights-query-builder.test.ts
+++ b/apps/server/test/utils/insights-query-builder.test.ts
@@ -1,24 +1,115 @@
 import { describe, it } from 'node:test';
 import * as assert from 'node:assert';
-import type { FilterInsightsInputType } from '../../src/schema/integrations/integration-types';
+import { DeviceEnum, PublisherEnum } from '@repo/database';
+import type {
+  FilterInsightsInputType,
+  InsightsDatapointsInputType,
+} from '../../src/schema/integrations/integration-types';
 import {
   getOrganizationalInsights,
   groupedInsights,
+  insightsDatapoints,
   lastInterval,
   orderColumnTrend,
 } from '../../src/utils/insights-query-builder';
 
+const getNoEmptyLines = (str: string) =>
+  str
+    .replace(/\n\s*\n/g, '\n')
+    .split('\n')
+    .map((l) => l.replace(/\s+/g, ' '))
+    .join('\n');
+
+const assertSql = (actual: string, expected: string) => {
+  const actualNoEmptyLines = getNoEmptyLines(actual);
+  const expectedNoEmptyLines = getNoEmptyLines(expected);
+  assert.strictEqual(actualNoEmptyLines, expectedNoEmptyLines);
+};
+
 void describe('insights query builder tests', () => {
-  void it('get insights', () => {
-    const insights = getOrganizationalInsights('clwkdrdn7000008k708vfchyr');
-    assert.strictEqual(
+  void it('get insights no filters', () => {
+    const args: FilterInsightsInputType = {
+      orderBy: 'spend',
+      page: 1,
+      pageSize: 10,
+      dataPointsPerInterval: 3,
+      groupBy: ['adId', 'publisher'],
+      interval: 'week',
+      order: 'desc',
+    };
+
+    const insights = getOrganizationalInsights('clwkdrdn7000008k708vfchyr', args);
+    assertSql(
       insights,
       `organization_insights AS (SELECT i.*
                                               FROM insights i
                                                        JOIN ads a on i.ad_id = a.id
                                                        JOIN ad_accounts aa on a.ad_account_id = aa.id
                                                        JOIN integrations int on aa.integration_id = int.id
-                                              WHERE int.organization_id = 'clwkdrdn7000008k708vfchyr')`,
+                                              WHERE int.organization_id = 'clwkdrdn7000008k708vfchyr'
+                                              )`,
+    );
+  });
+  void it('get insights ad account filter', () => {
+    const args: FilterInsightsInputType = {
+      adAccountIds: ['clwnaip1s000008k00nuu3xez', 'clwnaivx3000108k04kc7a491'],
+      orderBy: 'spend',
+      page: 1,
+      pageSize: 10,
+      dataPointsPerInterval: 3,
+      groupBy: ['adId', 'publisher'],
+      interval: 'week',
+      order: 'desc',
+    };
+
+    const insights = getOrganizationalInsights('clwkdrdn7000008k708vfchyr', args);
+    assertSql(
+      insights,
+      `organization_insights AS (SELECT i.*
+                                              FROM insights i
+                                                       JOIN ads a on i.ad_id = a.id
+                                                       JOIN ad_accounts aa on a.ad_account_id = aa.id
+                                                       JOIN integrations int on aa.integration_id = int.id
+                                              WHERE int.organization_id = 'clwkdrdn7000008k708vfchyr'
+                                                AND aa.id IN ('clwnaip1s000008k00nuu3xez', 'clwnaivx3000108k04kc7a491')
+                                              )`,
+    );
+  });
+  void it('get insights all filters', () => {
+    const args: FilterInsightsInputType = {
+      adAccountIds: ['clwnaip1s000008k00nuu3xez', 'clwnaivx3000108k04kc7a491'],
+      adIds: ['clwnqvgwx000008mlbmkchjwg'],
+      dateFrom: new Date('2024-04-01'),
+      dateTo: new Date('2024-05-28'),
+      devices: [DeviceEnum.MobileWeb, DeviceEnum.MobileApp],
+      orderBy: 'spend',
+      page: 1,
+      pageSize: 10,
+      dataPointsPerInterval: 3,
+      groupBy: ['adId', 'publisher'],
+      interval: 'week',
+      order: 'desc',
+      positions: ['feed'],
+      publishers: [PublisherEnum.Facebook],
+    };
+
+    const insights = getOrganizationalInsights('clwkdrdn7000008k708vfchyr', args);
+    assertSql(
+      insights,
+      `organization_insights AS (SELECT i.*
+                                              FROM insights i
+                                                       JOIN ads a on i.ad_id = a.id
+                                                       JOIN ad_accounts aa on a.ad_account_id = aa.id
+                                                       JOIN integrations int on aa.integration_id = int.id
+                                              WHERE int.organization_id = 'clwkdrdn7000008k708vfchyr'
+                                                AND aa.id IN ('clwnaip1s000008k00nuu3xez', 'clwnaivx3000108k04kc7a491')
+                                                AND a.id IN ('clwnqvgwx000008mlbmkchjwg')
+                                                AND i.date >= TIMESTAMP '2024-04-01T00:00:00.000Z'
+                                                AND i.date < TIMESTAMP '2024-05-28T00:00:00.000Z'
+                                                AND i.device IN ('MobileWeb', 'MobileApp')
+                                                AND i.position IN ('feed')
+                                                AND i.publisher IN ('Facebook')
+                                              )`,
     );
   });
   void it('last interval and order by it', () => {
@@ -43,6 +134,17 @@ void describe('insights query builder tests', () => {
                                       GROUP BY ad_id, publisher)`,
     );
   });
+  void it('last interval date to filter', () => {
+    const insights = lastInterval('ad_id, publisher', 'week', 'spend', false, new Date('2024-05-28'));
+    assert.strictEqual(
+      insights,
+      `last_interval AS (SELECT ad_id, publisher, SUM(i.spend) AS spend
+                                      FROM organization_insights i
+                                      WHERE date >= DATE_TRUNC('week', TIMESTAMP '2024-05-28T00:00:00.000Z' - INTERVAL '1 week')
+                                        AND date < DATE_TRUNC('week', TIMESTAMP '2024-05-28T00:00:00.000Z')
+                                      GROUP BY ad_id, publisher)`,
+    );
+  });
   void it('interval before last', () => {
     const insights = lastInterval('ad_id, publisher', 'week', 'spend', false);
     assert.strictEqual(
@@ -51,6 +153,17 @@ void describe('insights query builder tests', () => {
                                       FROM organization_insights i
                                       WHERE date >= DATE_TRUNC('week', CURRENT_DATE - INTERVAL '1 week')
                                         AND date < DATE_TRUNC('week', CURRENT_DATE)
+                                      GROUP BY ad_id, publisher)`,
+    );
+  });
+  void it('interval before last dateTo', () => {
+    const insights = lastInterval('ad_id, publisher', 'week', 'spend', false, new Date('2024-05-28'));
+    assert.strictEqual(
+      insights,
+      `last_interval AS (SELECT ad_id, publisher, SUM(i.spend) AS spend
+                                      FROM organization_insights i
+                                      WHERE date >= DATE_TRUNC('week', TIMESTAMP '2024-05-28T00:00:00.000Z' - INTERVAL '1 week')
+                                        AND date < DATE_TRUNC('week', TIMESTAMP '2024-05-28T00:00:00.000Z')
                                       GROUP BY ad_id, publisher)`,
     );
   });
@@ -78,24 +191,25 @@ void describe('insights query builder tests', () => {
     };
     const organizationId = 'clwkdrdn7000008k708vfchyr';
     const insights = groupedInsights(args, organizationId);
-    assert.strictEqual(
+    assertSql(
       insights,
       `WITH organization_insights AS (SELECT i.*
                                               FROM insights i
                                                        JOIN ads a on i.ad_id = a.id
                                                        JOIN ad_accounts aa on a.ad_account_id = aa.id
                                                        JOIN integrations int on aa.integration_id = int.id
-                                              WHERE int.organization_id = 'clwkdrdn7000008k708vfchyr'), 
+                                              WHERE int.organization_id = 'clwkdrdn7000008k708vfchyr'
+                                              ), 
   last_interval AS (SELECT ad_id, publisher, currency, SUM(i.spend) AS spend
                                       FROM organization_insights i
                                       WHERE date >= DATE_TRUNC('week', CURRENT_DATE - INTERVAL '1 week')
                                         AND date < DATE_TRUNC('week', CURRENT_DATE)
-                                      GROUP BY ad_id, publisher, currency), 
+                                      GROUP BY ad_id, publisher, currency),
   interval_before_last AS (SELECT ad_id, publisher, currency, SUM(i.spend) AS spend
                                              FROM organization_insights i
                                              WHERE date >= DATE_TRUNC('week', CURRENT_DATE - INTERVAL '2 week')
                                                AND date < DATE_TRUNC('week', CURRENT_DATE - INTERVAL '1 week')
-                                             GROUP BY ad_id, publisher, currency), 
+                                             GROUP BY ad_id, publisher, currency),
   order_column_trend AS (SELECT li.ad_id, li.publisher, li.currency, li.spend / ibl.spend::decimal trend
                                       FROM last_interval li JOIN interval_before_last ibl ON li.ad_id = ibl.ad_id AND li.publisher = ibl.publisher AND li.currency = ibl.currency
                                       WHERE ibl.spend
@@ -109,5 +223,86 @@ void describe('insights query builder tests', () => {
   GROUP BY i.ad_id, i.publisher, i.currency, interval_start, oct.trend
   ORDER BY oct.trend, interval_start DESC;`,
     );
+  });
+  void it('grouped insights with date filter', () => {
+    const args: FilterInsightsInputType = {
+      orderBy: 'spend',
+      page: 1,
+      pageSize: 10,
+      dataPointsPerInterval: 3,
+      dateFrom: new Date('2024-04-01'),
+      dateTo: new Date('2024-05-28'),
+      groupBy: ['adId', 'publisher'],
+      interval: 'week',
+      order: 'desc',
+    };
+    const organizationId = 'clwkdrdn7000008k708vfchyr';
+    const insights = groupedInsights(args, organizationId);
+    assertSql(
+      insights,
+      `WITH organization_insights AS (SELECT i.*
+                                              FROM insights i
+                                                       JOIN ads a on i.ad_id = a.id
+                                                       JOIN ad_accounts aa on a.ad_account_id = aa.id
+                                                       JOIN integrations int on aa.integration_id = int.id
+                                              WHERE int.organization_id = 'clwkdrdn7000008k708vfchyr'
+                                                AND i.date >= TIMESTAMP '2024-04-01T00:00:00.000Z'
+                                                AND i.date < TIMESTAMP '2024-05-28T00:00:00.000Z'
+                                              ), 
+  last_interval AS (SELECT ad_id, publisher, currency, SUM(i.spend) AS spend
+                                      FROM organization_insights i
+                                      WHERE date >= DATE_TRUNC('week', TIMESTAMP '2024-05-28T00:00:00.000Z' - INTERVAL '1 week')
+                                        AND date < DATE_TRUNC('week', TIMESTAMP '2024-05-28T00:00:00.000Z')
+                                      GROUP BY ad_id, publisher, currency),
+  interval_before_last AS (SELECT ad_id, publisher, currency, SUM(i.spend) AS spend
+                                             FROM organization_insights i
+                                             WHERE date >= DATE_TRUNC('week', TIMESTAMP '2024-05-28T00:00:00.000Z' - INTERVAL '2 week')
+                                               AND date < DATE_TRUNC('week', TIMESTAMP '2024-05-28T00:00:00.000Z' - INTERVAL '1 week')
+                                             GROUP BY ad_id, publisher, currency),
+  order_column_trend AS (SELECT li.ad_id, li.publisher, li.currency, li.spend / ibl.spend::decimal trend
+                                      FROM last_interval li JOIN interval_before_last ibl ON li.ad_id = ibl.ad_id AND li.publisher = ibl.publisher AND li.currency = ibl.currency
+                                      WHERE ibl.spend
+                                          > 0
+                                      ORDER BY trend
+                                      LIMIT 10 OFFSET 0)
+  SELECT i.ad_id, i.publisher, i.currency, DATE_TRUNC('week', i.date) interval_start, CAST(SUM(i.spend) AS NUMERIC) AS spend, CAST(SUM(i.impressions) AS NUMERIC) AS impressions 
+  FROM organization_insights i JOIN order_column_trend oct ON i.ad_id = oct.ad_id AND i.publisher = oct.publisher AND i.currency = oct.currency
+  WHERE i.date >= DATE_TRUNC('week', TIMESTAMP '2024-05-28T00:00:00.000Z' - INTERVAL '3 week')
+    AND i.date < DATE_TRUNC('week', TIMESTAMP '2024-05-28T00:00:00.000Z')
+  GROUP BY i.ad_id, i.publisher, i.currency, interval_start, oct.trend
+  ORDER BY oct.trend, interval_start DESC;`,
+    );
+  });
+  void it('insights datapoints', () => {
+    const args: InsightsDatapointsInputType = {
+      adAccountId: 'clwnaip1s000008k00nuu3xez',
+      adId: 'clwojj3kp000008l7bfk10qg1',
+      dateFrom: new Date('2024-04-01'),
+      dateTo: new Date('2024-05-27'),
+      device: DeviceEnum.MobileWeb,
+      interval: 'week',
+      position: 'feed',
+      publisher: PublisherEnum.Facebook,
+    };
+    const organizationId = 'clwkdrdn7000008k708vfchyr';
+    const insights = insightsDatapoints(args, organizationId);
+    const expected = `SELECT DATE_TRUNC('week', i.date)          AS date,
+                             CAST(SUM(i.spend) AS NUMERIC)       AS spend,
+                             CAST(SUM(i.impressions) AS NUMERIC) AS impressions
+                      FROM insights i
+                               JOIN ads a on i.ad_id = a.id
+                               JOIN ad_accounts aa on a.ad_account_id = aa.id
+                               JOIN integrations int on aa.integration_id = int.id
+                      WHERE int.organization_id = 'clwkdrdn7000008k708vfchyr'
+                        AND i.date >= DATE_TRUNC('week', TIMESTAMP '2024-04-01T00:00:00.000Z')
+                        AND i.date < DATE_TRUNC('week', TIMESTAMP '2024-05-27T00:00:00.000Z')
+                        AND i.ad_account_id = 'clwnaip1s000008k00nuu3xez'
+                        AND i.ad_id = 'clwojj3kp000008l7bfk10qg1'
+                        AND i.device = 'MobileWeb'
+                        AND i.position = 'feed'
+                        AND i.publisher = 'Facebook'
+                      GROUP BY date
+                      ORDER BY date DESC;`;
+    assertSql(insights, expected);
   });
 });

--- a/apps/web/src/graphql/generated/schema-client.ts
+++ b/apps/web/src/graphql/generated/schema-client.ts
@@ -367,6 +367,17 @@ export type InsightsDatapoints = {
   spend: Scalars['Int']['output'];
 };
 
+export type InsightsDatapointsInput = {
+  adAccountId?: InputMaybe<Scalars['String']['input']>;
+  adId?: InputMaybe<Scalars['String']['input']>;
+  dateFrom: Scalars['Date']['input'];
+  dateTo: Scalars['Date']['input'];
+  device?: InputMaybe<DeviceEnum>;
+  interval: InsightsInterval;
+  position?: InputMaybe<InsightsPosition>;
+  publisher?: InputMaybe<PublisherEnum>;
+};
+
 export enum InsightsInterval {
   day = 'day',
   week = 'week',
@@ -557,6 +568,7 @@ export enum PublisherEnum {
 export type Query = {
   __typename?: 'Query';
   generateGoogleAuthUrl: GenerateGoogleAuthUrlResponse;
+  insightDatapoints: Array<InsightsDatapoints>;
   insights: GroupedInsight;
   integrations: Array<Integration>;
   lastThreeMonthsAds: Array<Ad>;
@@ -566,6 +578,10 @@ export type Query = {
 
 export type QueryGenerateGoogleAuthUrlArgs = {
   state: Scalars['String']['input'];
+};
+
+export type QueryInsightDatapointsArgs = {
+  args: InsightsDatapointsInput;
 };
 
 export type QueryInsightsArgs = {

--- a/apps/web/src/graphql/generated/schema-server.ts
+++ b/apps/web/src/graphql/generated/schema-server.ts
@@ -366,6 +366,17 @@ export type InsightsDatapoints = {
   spend: Scalars['Int']['output'];
 };
 
+export type InsightsDatapointsInput = {
+  adAccountId?: InputMaybe<Scalars['String']['input']>;
+  adId?: InputMaybe<Scalars['String']['input']>;
+  dateFrom: Scalars['Date']['input'];
+  dateTo: Scalars['Date']['input'];
+  device?: InputMaybe<DeviceEnum>;
+  interval: InsightsInterval;
+  position?: InputMaybe<InsightsPosition>;
+  publisher?: InputMaybe<PublisherEnum>;
+};
+
 export enum InsightsInterval {
   day = 'day',
   week = 'week',
@@ -556,6 +567,7 @@ export enum PublisherEnum {
 export type Query = {
   __typename?: 'Query';
   generateGoogleAuthUrl: GenerateGoogleAuthUrlResponse;
+  insightDatapoints: Array<InsightsDatapoints>;
   insights: GroupedInsight;
   integrations: Array<Integration>;
   lastThreeMonthsAds: Array<Ad>;
@@ -565,6 +577,10 @@ export type Query = {
 
 export type QueryGenerateGoogleAuthUrlArgs = {
   state: Scalars['String']['input'];
+};
+
+export type QueryInsightDatapointsArgs = {
+  args: InsightsDatapointsInput;
 };
 
 export type QueryInsightsArgs = {

--- a/packages/database/src/config.ts
+++ b/packages/database/src/config.ts
@@ -2,7 +2,10 @@ import { z } from 'zod';
 import { createEnv } from '@repo/utils';
 
 const schema = z.object({
-  DATABASE_URL: z.string().regex(/^"?postgres(?:ql|):\/\/.*:?.*?@.*(?::.*)?\/.*/),
+  DATABASE_URL: z
+    .string()
+    .regex(/^"?postgres(?:ql|):\/\/.*:?.*?@.*(?::.*)?\/.*/)
+    .default('postgresql://postgres@localhost:5432/adsviewer'),
   DATABASE_RO_URL: z
     .string()
     .regex(/^"?postgres(?:ql|):\/\/.*:?.*?@.*(?::.*)?\/.*/)


### PR DESCRIPTION
## Description

Now we can get datapoint for a specific grouping filtered by a date range. 

keep in mind that these dates will be moved at the beginning of the interval. For example if you put from Apr 2nd (Tuesday) to May 28th (also Tuesday), the data range will be `>= Apr 1st and < May 27th`

Other than that filtering does work again on insigts and test are being executed when on commit and on pull request, the later in the ci/cd