### PR TITLE
enhance readme with aws cli configuration

### DIFF
--- a/.idea/aws.xml
+++ b/.idea/aws.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="accountSettings">
-    <option name="activeProfile" value="profile:891377180436_AdministratorAccess" />
     <option name="activeRegion" value="eu-central-1" />
     <option name="recentlyUsedProfiles">
       <list>
+        <option value="profile:654654420059_AdministratorAccess" />
         <option value="profile:891377180436_AdministratorAccess" />
         <option value="profile:default" />
       </list>

--- a/README.md
+++ b/README.md
@@ -31,3 +31,22 @@ A bunch of cool staff for viewing, optimizing and growing yor digital ad portfol
 6. Run `pnpm i`
 7. `pnpm run dev`
 8. Open [http://localhost:3000](http://localhost:3000)
+
+### Configuring aws-cli
+
+#### Prerequisites
+
+- [aws-cli](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+
+#### Setup
+
+There should be a `~/.aws/credentials` file, this will be used to authenticate with aws services. In order to get
+credentials you visit the [AWS access portal](https://d-9067fd5baf.awsapps.com/start/#/?tab=accounts) open
+the `development account` and click on `Access keys`. Scroll down to Option 2 and click copy. Then paste the content in
+the `~/.aws/credentials` file.
+
+#### Everyday hustle
+
+The credentials that you generated above will expire every 12 hours. In order to refresh them you need to repeat the
+process. On the flip side, very few features require aws services to be run locally (sending emails on forget password
+flow is an example). So you can skip this step if you believe you won't need them.


### PR DESCRIPTION
## Description

Forget password flow requires the backend to send emails tthrough aws. In order to be able to do so, you will need to install and configure aws-cli
