### PR TITLE
start database script

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "dev": "cross-env NODE_ENV=development pnpm --filter=@repo/database db:migrate:deploy && tsx watch --env-file=.env src/index.ts",
+    "dev": "cross-env NODE_ENV=development pnpm --filter=@repo/database start && tsx watch --env-file=.env src/index.ts",
     "build": "tsc",
     "start": "node --conditions=javascript --import=extensionless/register dist/index.js",
     "lint": "eslint . --max-warnings 0",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "dev": "concurrently 'pnpm db:migrate:deploy' 'pnpm generate:watch'",
+    "start": "concurrently 'pnpm db:migrate:deploy' 'pnpm generate:watch'",
     "db:migrate:deploy": "prisma migrate deploy",
     "db:migrate:dev": "prisma migrate dev --create-only",
     "db:migrate:revert": "npx prisma migrate diff --to-schema-datamodel prisma/schema.prisma --from-schema-datasource prisma/schema.prisma --script > down.sql",


### PR DESCRIPTION
## Description

For some reason if you excecute pnpm dev the dev script in database erases the log output. It does not happen if the script is called from the dev of the server.

This seems like a prisma bug