### PR TITLE
104: delete data on channel revoke

### DIFF
--- a/packages/channel-utils/src/integration-util.ts
+++ b/packages/channel-utils/src/integration-util.ts
@@ -9,7 +9,8 @@ export const authEndpoint = '/channel/auth';
 export type AdAccountEssential = Pick<AdAccount, 'id' | 'externalId' | 'currency'>;
 
 export const revokeIntegration = async (externalId: string, type: IntegrationTypeEnum): Promise<void> => {
-  await prisma.integration.update({
+  const { adAccounts } = await prisma.integration.update({
+    select: { adAccounts: true },
     where: {
       externalId_type: {
         externalId,
@@ -18,6 +19,13 @@ export const revokeIntegration = async (externalId: string, type: IntegrationTyp
     },
     data: {
       status: IntegrationStatus.REVOKED,
+    },
+  });
+  await prisma.adAccount.deleteMany({
+    where: {
+      id: {
+        in: adAccounts.map((adAccount) => adAccount.id),
+      },
     },
   });
 };

--- a/packages/database/prisma/migrations/20240606131146_cascade_on_ad_acount_delete/migration.sql
+++ b/packages/database/prisma/migrations/20240606131146_cascade_on_ad_acount_delete/migration.sql
@@ -1,0 +1,17 @@
+-- DropForeignKey
+ALTER TABLE "ads" DROP CONSTRAINT "ads_ad_account_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "creatives" DROP CONSTRAINT "creatives_ad_account_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "insights" DROP CONSTRAINT "insights_ad_account_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "ads" ADD CONSTRAINT "ads_ad_account_id_fkey" FOREIGN KEY ("ad_account_id") REFERENCES "ad_accounts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "creatives" ADD CONSTRAINT "creatives_ad_account_id_fkey" FOREIGN KEY ("ad_account_id") REFERENCES "ad_accounts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "insights" ADD CONSTRAINT "insights_ad_account_id_fkey" FOREIGN KEY ("ad_account_id") REFERENCES "ad_accounts"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -143,7 +143,7 @@ model Ad {
 
   externalId String    @map("external_id")
   name       String
-  adAccount  AdAccount @relation(fields: [adAccountId], references: [id])
+  adAccount  AdAccount @relation(fields: [adAccountId], references: [id], onDelete: Cascade)
   insights   Insight[]
   creative   Creative? @relation(fields: [creativeId], references: [id])
 
@@ -175,7 +175,7 @@ model Creative {
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @default(now()) @updatedAt @map("updated_at")
 
-  adAccount AdAccount @relation(fields: [adAccountId], references: [id])
+  adAccount AdAccount @relation(fields: [adAccountId], references: [id], onDelete: Cascade)
   ads       Ad[]
 
   @@unique([adAccountId, name])
@@ -198,7 +198,7 @@ model Insight {
   position    String
 
   ad        Ad         @relation(fields: [adId], references: [id])
-  adAccount AdAccount? @relation(fields: [adAccountId], references: [id])
+  adAccount AdAccount? @relation(fields: [adAccountId], references: [id], onDelete: Cascade)
 
   @@unique([adId, date, device, publisher, position])
   @@index([adAccountId])


### PR DESCRIPTION
## Description

When a user revokes a integration we need to delete all their data, to be GDPR compliant. We would like to make it a bit difficault for the user to accidentaly revoke a integration. Here is how github implemented deleting a repository. I don't think that we need to be that excaustive but using something the last screen should do the trick.