### PR TITLE
don't require special character in password

### DIFF
--- a/packages/utils/src/password-helper.ts
+++ b/packages/utils/src/password-helper.ts
@@ -19,7 +19,4 @@ export const PasswordSchema = z
   })
   .refine(hasNumber, {
     message: 'Password needs to have at least 1 number',
-  })
-  .refine(hasSpecialCharacter, {
-    message: 'Password needs to have at least 1 special character',
   });


### PR DESCRIPTION
## Description

Google chrome password suggestion does not require a special character, neither should we.

