### PR TITLE
create refresh AuthenticatedContext

### DIFF
--- a/apps/server/src/schema/builder.ts
+++ b/apps/server/src/schema/builder.ts
@@ -19,6 +19,13 @@ export interface AuthenticatedContext extends GraphQLContext {
   organizationId: NonNullable<GraphQLContext['organizationId']>;
   isAdmin: NonNullable<GraphQLContext['isAdmin']>;
   isOrgAdmin: NonNullable<GraphQLContext['isOrgAdmin']>;
+  isRefreshToken: NonNullable<GraphQLContext['isRefreshToken']>;
+}
+
+export interface RefreshContext extends GraphQLContext {
+  currentUserId: NonNullable<GraphQLContext['currentUserId']>;
+  organizationId: NonNullable<GraphQLContext['organizationId']>;
+  isRefreshToken: NonNullable<GraphQLContext['isRefreshToken']>;
 }
 
 export const builder = new SchemaBuilder<{
@@ -38,9 +45,13 @@ export const builder = new SchemaBuilder<{
     authenticated: boolean;
     isAdmin: boolean;
     isOrgAdmin: boolean;
+    refresh: boolean;
   };
   AuthContexts: {
     authenticated: AuthenticatedContext;
+    isAdmin: AuthenticatedContext;
+    isOrgAdmin: AuthenticatedContext;
+    refresh: RefreshContext;
   };
 }>({
   plugins: [ErrorsPlugin, RelayPlugin, ScopeAuthPlugin, PrismaPlugin, SimpleObjectsPlugin, ValidationPlugin],
@@ -53,9 +64,10 @@ export const builder = new SchemaBuilder<{
     cursorType: 'ID',
   },
   authScopes: (context) => ({
-    authenticated: Boolean(context.currentUserId),
-    isAdmin: Boolean(context.isAdmin),
-    isOrgAdmin: Boolean(context.isOrgAdmin),
+    authenticated: Boolean(context.currentUserId) && !context.isRefreshToken,
+    isAdmin: Boolean(context.isAdmin) && !context.isRefreshToken,
+    isOrgAdmin: Boolean(context.isOrgAdmin) && !context.isRefreshToken,
+    refresh: Boolean(context.isRefreshToken),
   }),
   scopeAuthOptions: {
     // Recommended when using subscriptions

--- a/apps/server/src/schema/user/organization-operations.ts
+++ b/apps/server/src/schema/user/organization-operations.ts
@@ -101,11 +101,17 @@ builder.mutationFields((t) => ({
       if (!user) {
         throw new GraphQLError('You do not have permission to switch to this organization');
       }
-      const { token, refreshToken } = await createJwts(
-        user.id,
-        user.defaultOrganizationId,
-        user.roles.map((r) => r.role),
-      );
+      const [{ token, refreshToken }] = await Promise.all([
+        createJwts(
+          user.id,
+          args.organizationId,
+          user.roles.map((r) => r.role),
+        ),
+        prisma.user.update({
+          where: { id: user.id },
+          data: { defaultOrganizationId: args.organizationId },
+        }),
+      ]);
       return { token, refreshToken };
     },
   }),


### PR DESCRIPTION
## Description

right now the refreshToken can be used in the place of the normal token. This was not intended, the refresh token should be used only for hitting the refresh endpoint, it should returh 403 on all other endpoints that require authentication


