### PR TITLE
make defaultOrganizationId optional

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -7,14 +7,14 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "dev": "cross-env NODE_ENV=development pnpm --filter=@repo/database start-dev && tsx watch --env-file=.env src/index.ts",
+    "dev": "cross-env NODE_ENV=development concurrently 'pnpm codegen --watch' 'pnpm --filter=@repo/database start-dev' 'tsx watch --env-file=.env src/index.ts'",
     "build": "tsc",
     "start": "node --conditions=javascript --import=extensionless/register dist/index.js",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "clean": "rm -rf dist node_modules .turbo",
     "update": "pnpm update --latest",
-    "codegen": "tsx --env-file=.env src/schema/codegen.ts",
+    "codegen": "graphql-codegen -c src/schema/codegen.ts",
     "test": "node --import tsx --test test/**/*.test.ts"
   },
   "dependencies": {
@@ -42,6 +42,7 @@
     "body-parser": "^1.20.2",
     "change-case": "^5.4.4",
     "cross-env": "^7.0.3",
+    "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "extensionless": "^1.9.9",
     "google-auth-library": "^9.10.0",
@@ -72,6 +73,7 @@
     "@types/node": "20.14.2",
     "@types/qs": "^6.9.15",
     "@types/sns-validator": "^0.3.3",
+    "concurrently": "^8.2.2",
     "tsx": "^4.11.2",
     "typescript": "5.4.5"
   }

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -20,12 +20,14 @@ const { sign, verify } = jwt;
 
 const expiresIn = MODE === Environment.Local ? '365d' : '5m';
 
-export const createJwts = async (userId: string, organizationId: string, roles: RoleEnum[]) => {
-  const { role } = await prisma.userOrganization.findUniqueOrThrow({
-    select: { role: true },
-    where: { userId_organizationId: { userId, organizationId } },
-  });
-  roles.push(role as RoleEnum);
+export const createJwts = async (userId: string, organizationId: string | null, roles: RoleEnum[]) => {
+  if (organizationId) {
+    const { role } = await prisma.userOrganization.findUniqueOrThrow({
+      select: { role: true },
+      where: { userId_organizationId: { userId, organizationId } },
+    });
+    roles.push(role as RoleEnum);
+  }
   return {
     token: sign({ userId, organizationId, roles }, env.AUTH_SECRET, { expiresIn }),
     refreshToken: sign({ userId, organizationId, type: 'refresh' }, env.REFRESH_SECRET, { expiresIn: '183d' }),

--- a/apps/server/src/context.ts
+++ b/apps/server/src/context.ts
@@ -12,6 +12,7 @@ export interface GraphQLContext {
   acceptedLanguage: Language;
   isAdmin: boolean | undefined;
   isOrgAdmin: boolean | undefined;
+  isInOrg: boolean | undefined;
   isRefreshToken: boolean | undefined;
   request: {
     operatingSystem: string;
@@ -33,7 +34,10 @@ export const createContext = (initialContext: YogaInitialContext): GraphQLContex
     currentUserId: token?.userId,
     organizationId: token?.organizationId,
     isAdmin: token?.roles?.includes(RoleEnum.ADMIN),
-    isOrgAdmin: token?.roles?.includes(OrganizationRoleEnum.ORG_ADMIN),
+    isOrgAdmin: token?.roles?.includes(OrganizationRoleEnum.ORG_MEMBER),
+    isInOrg: token?.roles?.some((r) =>
+      [OrganizationRoleEnum.ORG_ADMIN, OrganizationRoleEnum.ORG_MEMBER].includes(r as OrganizationRoleEnum),
+    ),
     acceptedLanguage: acceptedLanguage(initialContext.request),
     request: {
       operatingSystem,

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import express, { type Request, type Response } from 'express';
 import { createYoga } from 'graphql-yoga';
 import { useDisableIntrospection } from '@graphql-yoga/plugin-disable-introspection';

--- a/apps/server/src/schema/builder.ts
+++ b/apps/server/src/schema/builder.ts
@@ -16,10 +16,13 @@ import JsonValue = Prisma.JsonValue;
 
 export interface AuthenticatedContext extends GraphQLContext {
   currentUserId: NonNullable<GraphQLContext['currentUserId']>;
+}
+
+export interface InOrganizationContext extends GraphQLContext {
+  currentUserId: NonNullable<GraphQLContext['currentUserId']>;
   organizationId: NonNullable<GraphQLContext['organizationId']>;
   isAdmin: NonNullable<GraphQLContext['isAdmin']>;
   isOrgAdmin: NonNullable<GraphQLContext['isOrgAdmin']>;
-  isRefreshToken: NonNullable<GraphQLContext['isRefreshToken']>;
 }
 
 export interface RefreshContext extends GraphQLContext {
@@ -45,12 +48,14 @@ export const builder = new SchemaBuilder<{
     authenticated: boolean;
     isAdmin: boolean;
     isOrgAdmin: boolean;
+    isInOrg: boolean;
     refresh: boolean;
   };
   AuthContexts: {
     authenticated: AuthenticatedContext;
     isAdmin: AuthenticatedContext;
-    isOrgAdmin: AuthenticatedContext;
+    isOrgAdmin: InOrganizationContext;
+    isInOrg: InOrganizationContext;
     refresh: RefreshContext;
   };
 }>({
@@ -67,6 +72,7 @@ export const builder = new SchemaBuilder<{
     authenticated: Boolean(context.currentUserId) && !context.isRefreshToken,
     isAdmin: Boolean(context.isAdmin) && !context.isRefreshToken,
     isOrgAdmin: Boolean(context.isOrgAdmin) && !context.isRefreshToken,
+    isInOrg: Boolean(context.isInOrg) && !context.isRefreshToken,
     refresh: Boolean(context.isRefreshToken),
   }),
   scopeAuthOptions: {

--- a/apps/server/src/schema/codegen.ts
+++ b/apps/server/src/schema/codegen.ts
@@ -1,9 +1,10 @@
+import 'dotenv/config';
 import { printSchema } from 'graphql';
 import type { CodegenConfig } from '@graphql-codegen/cli';
-import { generate } from '@graphql-codegen/cli';
 import { schema } from '.';
 
 const config: CodegenConfig = {
+  watch: false,
   schema: printSchema(schema),
   emitLegacyCommonJSImports: false,
   generates: {
@@ -62,6 +63,5 @@ const config: CodegenConfig = {
   hooks: { afterAllFileWrite: ['prettier --write'] },
 };
 
-await generate(config);
-
-process.exit(0);
+// eslint-disable-next-line import/no-default-export -- This is needed  as per documentation: https://the-guild.dev/graphql/codegen/docs/getting-started/esm-typescript-usage#codegen-configuration
+export default config;

--- a/apps/server/src/schema/generated/schema.graphql
+++ b/apps/server/src/schema/generated/schema.graphql
@@ -555,7 +555,7 @@ type User {
   allRoles: [AllRoles!]!
   createdAt: Date!
   defaultOrganization: Organization!
-  defaultOrganizationId: String!
+  defaultOrganizationId: String
   email: String!
   firstName: String!
   id: ID!

--- a/apps/server/src/schema/integrations/insights-operations.ts
+++ b/apps/server/src/schema/integrations/insights-operations.ts
@@ -36,7 +36,7 @@ builder.queryFields((t) => ({
       });
     },
   }),
-  insights: t.withAuth({ authenticated: true }).field({
+  insights: t.withAuth({ isInOrg: true }).field({
     type: GroupedInsightsDto,
     args: {
       filter: t.arg({ type: FilterInsightsInput, required: true }),
@@ -168,7 +168,7 @@ builder.queryFields((t) => ({
     },
   }),
 
-  insightDatapoints: t.withAuth({ authenticated: true }).field({
+  insightDatapoints: t.withAuth({ isInOrg: true }).field({
     type: [InsightsDatapointsDto],
     args: {
       args: t.arg({ type: InsightsDatapointsInput, required: true }),

--- a/apps/server/src/schema/integrations/integration-operations.ts
+++ b/apps/server/src/schema/integrations/integration-operations.ts
@@ -32,7 +32,7 @@ builder.queryFields((t) => ({
       });
     },
   }),
-  settingsChannels: t.withAuth({ authenticated: true }).field({
+  settingsChannels: t.withAuth({ isInOrg: true }).field({
     type: [IntegrationListItemDto],
     resolve: async (_root, _args, ctx, _info) => {
       const integrations = await prisma.integration.findMany({
@@ -58,7 +58,7 @@ builder.queryFields((t) => ({
 }));
 
 builder.mutationFields((t) => ({
-  deAuthIntegration: t.withAuth({ authenticated: true }).field({
+  deAuthIntegration: t.withAuth({ isOrgAdmin: true }).field({
     type: 'String',
     errors: { types: [MetaError, AError] },
     args: {

--- a/apps/server/src/schema/user/organization-operations.ts
+++ b/apps/server/src/schema/user/organization-operations.ts
@@ -65,12 +65,13 @@ builder.mutationFields((t) => ({
       organizationId: t.arg.string({ required: true }),
     },
     resolve: async (query, _root, args, ctx, _info) => {
-      const deleteOrg = prisma.organization.delete({
-        ...query,
-        where: { id: args.organizationId },
-      });
+      const deleteOrg = () =>
+        prisma.organization.delete({
+          ...query,
+          where: { id: args.organizationId },
+        });
       if (ctx.isOrgAdmin && ctx.organizationId === args.organizationId) {
-        return deleteOrg;
+        return deleteOrg();
       }
       const userOrg = await prisma.userOrganization.findUnique({
         where: {
@@ -81,7 +82,7 @@ builder.mutationFields((t) => ({
       if (!userOrg) {
         throw new GraphQLError('You do not have permission to delete this organization');
       }
-      return deleteOrg;
+      return deleteOrg();
     },
   }),
 

--- a/apps/server/src/schema/user/user-types.ts
+++ b/apps/server/src/schema/user/user-types.ts
@@ -40,7 +40,7 @@ export const UserDto = builder.prismaObject('User', {
       },
     }),
     organizations: t.relation('organizations'),
-    defaultOrganizationId: t.exposeString('defaultOrganizationId', { nullable: false }),
+    defaultOrganizationId: t.exposeString('defaultOrganizationId', { nullable: true }),
     defaultOrganization: t.relation('defaultOrganization', { nullable: false, type: OrganizationDto }),
   }),
 });

--- a/apps/web-old/src/graphql/generated/schema-client.ts
+++ b/apps/web-old/src/graphql/generated/schema-client.ts
@@ -668,7 +668,7 @@ export type User = {
   allRoles: Array<AllRoles>;
   createdAt: Scalars['Date']['output'];
   defaultOrganization: Organization;
-  defaultOrganizationId: Scalars['String']['output'];
+  defaultOrganizationId?: Maybe<Scalars['String']['output']>;
   email: Scalars['String']['output'];
   firstName: Scalars['String']['output'];
   id: Scalars['ID']['output'];
@@ -821,7 +821,7 @@ export type LoginMutation = {
       lastName: string;
       email: string;
       allRoles: Array<AllRoles>;
-      defaultOrganizationId: string;
+      defaultOrganizationId?: string | null;
     };
   };
 };
@@ -846,7 +846,7 @@ export type SignupMutation = {
       lastName: string;
       email: string;
       allRoles: Array<AllRoles>;
-      defaultOrganizationId: string;
+      defaultOrganizationId?: string | null;
     };
   };
 };
@@ -875,7 +875,7 @@ export type ResetPasswordMutation = {
       lastName: string;
       email: string;
       allRoles: Array<AllRoles>;
-      defaultOrganizationId: string;
+      defaultOrganizationId?: string | null;
     };
   };
 };
@@ -905,7 +905,7 @@ export type UserFieldsFragment = {
   lastName: string;
   email: string;
   allRoles: Array<AllRoles>;
-  defaultOrganizationId: string;
+  defaultOrganizationId?: string | null;
 };
 
 export const UserFieldsFragmentDoc = gql`

--- a/apps/web-old/src/graphql/generated/schema-server.ts
+++ b/apps/web-old/src/graphql/generated/schema-server.ts
@@ -667,7 +667,7 @@ export type User = {
   allRoles: Array<AllRoles>;
   createdAt: Scalars['Date']['output'];
   defaultOrganization: Organization;
-  defaultOrganizationId: Scalars['String']['output'];
+  defaultOrganizationId?: Maybe<Scalars['String']['output']>;
   email: Scalars['String']['output'];
   firstName: Scalars['String']['output'];
   id: Scalars['ID']['output'];
@@ -820,7 +820,7 @@ export type LoginMutation = {
       lastName: string;
       email: string;
       allRoles: Array<AllRoles>;
-      defaultOrganizationId: string;
+      defaultOrganizationId?: string | null;
     };
   };
 };
@@ -845,7 +845,7 @@ export type SignupMutation = {
       lastName: string;
       email: string;
       allRoles: Array<AllRoles>;
-      defaultOrganizationId: string;
+      defaultOrganizationId?: string | null;
     };
   };
 };
@@ -874,7 +874,7 @@ export type ResetPasswordMutation = {
       lastName: string;
       email: string;
       allRoles: Array<AllRoles>;
-      defaultOrganizationId: string;
+      defaultOrganizationId?: string | null;
     };
   };
 };
@@ -904,7 +904,7 @@ export type UserFieldsFragment = {
   lastName: string;
   email: string;
   allRoles: Array<AllRoles>;
-  defaultOrganizationId: string;
+  defaultOrganizationId?: string | null;
 };
 
 export const UserFieldsFragmentDoc = gql`

--- a/apps/web/src/graphql/generated/schema-client.ts
+++ b/apps/web/src/graphql/generated/schema-client.ts
@@ -668,7 +668,7 @@ export type User = {
   allRoles: Array<AllRoles>;
   createdAt: Scalars['Date']['output'];
   defaultOrganization: Organization;
-  defaultOrganizationId: Scalars['String']['output'];
+  defaultOrganizationId?: Maybe<Scalars['String']['output']>;
   email: Scalars['String']['output'];
   firstName: Scalars['String']['output'];
   id: Scalars['ID']['output'];
@@ -820,7 +820,7 @@ export type LoginMutation = {
       lastName: string;
       email: string;
       allRoles: Array<AllRoles>;
-      defaultOrganizationId: string;
+      defaultOrganizationId?: string | null;
     };
   };
 };
@@ -845,7 +845,7 @@ export type SignupMutation = {
       lastName: string;
       email: string;
       allRoles: Array<AllRoles>;
-      defaultOrganizationId: string;
+      defaultOrganizationId?: string | null;
     };
   };
 };
@@ -874,7 +874,7 @@ export type ResetPasswordMutation = {
       lastName: string;
       email: string;
       allRoles: Array<AllRoles>;
-      defaultOrganizationId: string;
+      defaultOrganizationId?: string | null;
     };
   };
 };
@@ -904,7 +904,7 @@ export type UserFieldsFragment = {
   lastName: string;
   email: string;
   allRoles: Array<AllRoles>;
-  defaultOrganizationId: string;
+  defaultOrganizationId?: string | null;
 };
 
 export const UserFieldsFragmentDoc = gql`

--- a/apps/web/src/graphql/generated/schema-server.ts
+++ b/apps/web/src/graphql/generated/schema-server.ts
@@ -667,7 +667,7 @@ export type User = {
   allRoles: Array<AllRoles>;
   createdAt: Scalars['Date']['output'];
   defaultOrganization: Organization;
-  defaultOrganizationId: Scalars['String']['output'];
+  defaultOrganizationId?: Maybe<Scalars['String']['output']>;
   email: Scalars['String']['output'];
   firstName: Scalars['String']['output'];
   id: Scalars['ID']['output'];
@@ -819,7 +819,7 @@ export type LoginMutation = {
       lastName: string;
       email: string;
       allRoles: Array<AllRoles>;
-      defaultOrganizationId: string;
+      defaultOrganizationId?: string | null;
     };
   };
 };
@@ -844,7 +844,7 @@ export type SignupMutation = {
       lastName: string;
       email: string;
       allRoles: Array<AllRoles>;
-      defaultOrganizationId: string;
+      defaultOrganizationId?: string | null;
     };
   };
 };
@@ -873,7 +873,7 @@ export type ResetPasswordMutation = {
       lastName: string;
       email: string;
       allRoles: Array<AllRoles>;
-      defaultOrganizationId: string;
+      defaultOrganizationId?: string | null;
     };
   };
 };
@@ -903,7 +903,7 @@ export type UserFieldsFragment = {
   lastName: string;
   email: string;
   allRoles: Array<AllRoles>;
-  defaultOrganizationId: string;
+  defaultOrganizationId?: string | null;
 };
 
 export const UserFieldsFragmentDoc = gql`

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "tsx": "^4.11.2",
     "turbo": "^2.0.3"
   },
-  "packageManager": "pnpm@9.1.4",
+  "packageManager": "pnpm@9.3.0",
   "engines": {
     "node": ">=20"
   },

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "start-dev": "concurrently 'pnpm db:migrate:deploy' 'pnpm generate'",
+    "start-dev": "concurrently 'pnpm db:migrate:deploy' 'pnpm generate:watch'",
     "db:migrate:deploy": "prisma migrate deploy",
     "db:migrate:dev": "prisma migrate dev --create-only",
     "db:migrate:revert": "npx prisma migrate diff --to-schema-datamodel prisma/schema.prisma --from-schema-datasource prisma/schema.prisma --script > down.sql",

--- a/packages/database/prisma/migrations/20240616191544_default_organization_optional/migration.sql
+++ b/packages/database/prisma/migrations/20240616191544_default_organization_optional/migration.sql
@@ -1,0 +1,9 @@
+-- DropForeignKey
+ALTER TABLE "users" DROP CONSTRAINT "users_default_organization_id_fkey";
+
+-- AlterTable
+ALTER TABLE "users" ALTER COLUMN "default_organization_id" DROP NOT NULL,
+ALTER COLUMN "email_type" DROP DEFAULT;
+
+-- AddForeignKey
+ALTER TABLE "users" ADD CONSTRAINT "users_default_organization_id_fkey" FOREIGN KEY ("default_organization_id") REFERENCES "organizations"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -48,8 +48,8 @@ model User {
   password              String?
   photoUrl              String?             @map("photo_url")
   roles                 UserRole[]
-  defaultOrganization   Organization        @relation(fields: [defaultOrganizationId], references: [id])
-  defaultOrganizationId String              @map("default_organization_id")
+  defaultOrganization   Organization?       @relation(fields: [defaultOrganizationId], references: [id])
+  defaultOrganizationId String?             @map("default_organization_id")
   createdAt             DateTime            @default(now()) @map("created_at")
   updatedAt             DateTime            @default(now()) @updatedAt @map("updated_at")
   loginProviders        LoginProviderUser[]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.4.5
       express:
         specifier: ^4.19.2
         version: 4.19.2
@@ -234,6 +237,9 @@ importers:
       '@types/sns-validator':
         specifier: ^0.3.3
         version: 0.3.3
+      concurrently:
+        specifier: ^8.2.2
+        version: 8.2.2
       tsx:
         specifier: ^4.11.2
         version: 4.11.2


### PR DESCRIPTION
When an organization is deleted the user may find themselves with no default organization, therefore we are forced to have this as optional.

Which means that there will be cases where the jwt will have no organizationId. This should be the trigger point for the front end to suggest to the user to create an organization

This PR improved the DX by enabling watch on prisma and .graphql files