### PR TITLE
fix resetPassword endpoint

### DIFF
--- a/apps/server/src/schema/user/user-operations.ts
+++ b/apps/server/src/schema/user/user-operations.ts
@@ -249,9 +249,8 @@ builder.mutationFields((t) => ({
 
       const [user, _] = await Promise.all([
         await prisma.user.update({
-          ...query,
+          ...lodash.merge({}, query, userWithRoles),
           where: { id: userId },
-          ...userWithRoles,
           data: { password },
         }),
         await redisDel(`forget-password:${args.token}`),


### PR DESCRIPTION
## Description

We were not using the lodash merge and the query was not honored. So as some point when the asked for organizations, the query blew up since it was not fetching them
