### PR TITLE
introduce organization query and restrict UserDto

### DIFF
--- a/apps/server/src/schema/generated/schema.graphql
+++ b/apps/server/src/schema/generated/schema.graphql
@@ -485,7 +485,7 @@ type Organization {
   integrations: [Integration!]!
   name: String!
   updatedAt: Date!
-  users: [UserOrganization!]!
+  userOrganizations: [UserOrganization!]!
 }
 
 enum OrganizationRoleEnum {
@@ -530,6 +530,7 @@ type Query {
   lastThreeMonthsAds: [Ad!]!
   loginProviders: [GenerateGoogleAuthUrlResponse!]!
   me: User!
+  organization: Organization!
   settingsChannels: [IntegrationListItem!]!
 }
 
@@ -555,16 +556,39 @@ type Tokens {
   token: String!
 }
 
+"""
+Caller is permitted to view this type if is the user or an admin. Some fields are also permitted if the caller and the user are in a common organization
+"""
 type User {
   allRoles: [AllRoles!]!
   createdAt: Date!
   currentOrganization: Organization
   currentOrganizationId: String
+
+  """
+  Caller is permitted to view this field if they are in a common organization
+  """
   email: String!
+
+  """
+  Caller is permitted to view this field if they are in a common organization
+  """
   firstName: String!
+
+  """
+  Caller is permitted to view this field if they are in a common organization
+  """
   id: ID!
+
+  """
+  Caller is permitted to view this field if they are in a common organization
+  """
   lastName: String!
   organizations: [UserOrganization!]!
+
+  """
+  Caller is permitted to view this field if they are in a common organization
+  """
   photoUrl: String
   status: UserStatus!
   updatedAt: Date!

--- a/apps/server/src/schema/organization/org-types.ts
+++ b/apps/server/src/schema/organization/org-types.ts
@@ -8,7 +8,7 @@ export const OrganizationDto = builder.prismaObject('Organization', {
     domain: t.exposeString('domain', { nullable: true }),
     createdAt: t.expose('createdAt', { type: 'Date' }),
     updatedAt: t.expose('updatedAt', { type: 'Date' }),
-    users: t.relation('users'),
+    userOrganizations: t.relation('users'),
     integrations: t.relation('integrations'),
   }),
 });

--- a/apps/server/src/schema/user/organization-operations.ts
+++ b/apps/server/src/schema/user/organization-operations.ts
@@ -6,6 +6,18 @@ import { userWithRoles } from '../../contexts/user';
 import { createJwts } from '../../auth';
 import { TokensDto } from './user-types';
 
+builder.queryFields((t) => ({
+  organization: t.withAuth({ isInOrg: true }).prismaField({
+    type: OrganizationDto,
+    resolve: (query, _root, _args, ctx, _info) => {
+      return prisma.organization.findUniqueOrThrow({
+        ...query,
+        where: { id: ctx.organizationId },
+      });
+    },
+  }),
+}));
+
 builder.mutationFields((t) => ({
   updateOrganization: t.withAuth({ isOrgAdmin: true }).prismaField({
     type: OrganizationDto,

--- a/apps/web-old/src/graphql/generated/schema-client.ts
+++ b/apps/web-old/src/graphql/generated/schema-client.ts
@@ -568,7 +568,7 @@ export type Organization = {
   integrations: Array<Integration>;
   name: Scalars['String']['output'];
   updatedAt: Scalars['Date']['output'];
-  users: Array<UserOrganization>;
+  userOrganizations: Array<UserOrganization>;
 };
 
 export enum OrganizationRoleEnum {
@@ -616,6 +616,7 @@ export type Query = {
   lastThreeMonthsAds: Array<Ad>;
   loginProviders: Array<GenerateGoogleAuthUrlResponse>;
   me: User;
+  organization: Organization;
   settingsChannels: Array<IntegrationListItem>;
 };
 
@@ -663,17 +664,23 @@ export type Tokens = {
   token: Scalars['String']['output'];
 };
 
+/** Caller is permitted to view this type if is the user or an admin. Some fields are also permitted if the caller and the user are in a common organization */
 export type User = {
   __typename?: 'User';
   allRoles: Array<AllRoles>;
   createdAt: Scalars['Date']['output'];
   currentOrganization?: Maybe<Organization>;
   currentOrganizationId?: Maybe<Scalars['String']['output']>;
+  /** Caller is permitted to view this field if they are in a common organization */
   email: Scalars['String']['output'];
+  /** Caller is permitted to view this field if they are in a common organization */
   firstName: Scalars['String']['output'];
+  /** Caller is permitted to view this field if they are in a common organization */
   id: Scalars['ID']['output'];
+  /** Caller is permitted to view this field if they are in a common organization */
   lastName: Scalars['String']['output'];
   organizations: Array<UserOrganization>;
+  /** Caller is permitted to view this field if they are in a common organization */
   photoUrl?: Maybe<Scalars['String']['output']>;
   status: UserStatus;
   updatedAt: Scalars['Date']['output'];

--- a/apps/web-old/src/graphql/generated/schema-server.ts
+++ b/apps/web-old/src/graphql/generated/schema-server.ts
@@ -567,7 +567,7 @@ export type Organization = {
   integrations: Array<Integration>;
   name: Scalars['String']['output'];
   updatedAt: Scalars['Date']['output'];
-  users: Array<UserOrganization>;
+  userOrganizations: Array<UserOrganization>;
 };
 
 export enum OrganizationRoleEnum {
@@ -615,6 +615,7 @@ export type Query = {
   lastThreeMonthsAds: Array<Ad>;
   loginProviders: Array<GenerateGoogleAuthUrlResponse>;
   me: User;
+  organization: Organization;
   settingsChannels: Array<IntegrationListItem>;
 };
 
@@ -662,17 +663,23 @@ export type Tokens = {
   token: Scalars['String']['output'];
 };
 
+/** Caller is permitted to view this type if is the user or an admin. Some fields are also permitted if the caller and the user are in a common organization */
 export type User = {
   __typename?: 'User';
   allRoles: Array<AllRoles>;
   createdAt: Scalars['Date']['output'];
   currentOrganization?: Maybe<Organization>;
   currentOrganizationId?: Maybe<Scalars['String']['output']>;
+  /** Caller is permitted to view this field if they are in a common organization */
   email: Scalars['String']['output'];
+  /** Caller is permitted to view this field if they are in a common organization */
   firstName: Scalars['String']['output'];
+  /** Caller is permitted to view this field if they are in a common organization */
   id: Scalars['ID']['output'];
+  /** Caller is permitted to view this field if they are in a common organization */
   lastName: Scalars['String']['output'];
   organizations: Array<UserOrganization>;
+  /** Caller is permitted to view this field if they are in a common organization */
   photoUrl?: Maybe<Scalars['String']['output']>;
   status: UserStatus;
   updatedAt: Scalars['Date']['output'];

--- a/apps/web/src/graphql/generated/schema-client.ts
+++ b/apps/web/src/graphql/generated/schema-client.ts
@@ -568,7 +568,7 @@ export type Organization = {
   integrations: Array<Integration>;
   name: Scalars['String']['output'];
   updatedAt: Scalars['Date']['output'];
-  users: Array<UserOrganization>;
+  userOrganizations: Array<UserOrganization>;
 };
 
 export enum OrganizationRoleEnum {
@@ -616,6 +616,7 @@ export type Query = {
   lastThreeMonthsAds: Array<Ad>;
   loginProviders: Array<GenerateGoogleAuthUrlResponse>;
   me: User;
+  organization: Organization;
   settingsChannels: Array<IntegrationListItem>;
 };
 
@@ -663,17 +664,23 @@ export type Tokens = {
   token: Scalars['String']['output'];
 };
 
+/** Caller is permitted to view this type if is the user or an admin. Some fields are also permitted if the caller and the user are in a common organization */
 export type User = {
   __typename?: 'User';
   allRoles: Array<AllRoles>;
   createdAt: Scalars['Date']['output'];
   currentOrganization?: Maybe<Organization>;
   currentOrganizationId?: Maybe<Scalars['String']['output']>;
+  /** Caller is permitted to view this field if they are in a common organization */
   email: Scalars['String']['output'];
+  /** Caller is permitted to view this field if they are in a common organization */
   firstName: Scalars['String']['output'];
+  /** Caller is permitted to view this field if they are in a common organization */
   id: Scalars['ID']['output'];
+  /** Caller is permitted to view this field if they are in a common organization */
   lastName: Scalars['String']['output'];
   organizations: Array<UserOrganization>;
+  /** Caller is permitted to view this field if they are in a common organization */
   photoUrl?: Maybe<Scalars['String']['output']>;
   status: UserStatus;
   updatedAt: Scalars['Date']['output'];

--- a/apps/web/src/graphql/generated/schema-server.ts
+++ b/apps/web/src/graphql/generated/schema-server.ts
@@ -567,7 +567,7 @@ export type Organization = {
   integrations: Array<Integration>;
   name: Scalars['String']['output'];
   updatedAt: Scalars['Date']['output'];
-  users: Array<UserOrganization>;
+  userOrganizations: Array<UserOrganization>;
 };
 
 export enum OrganizationRoleEnum {
@@ -615,6 +615,7 @@ export type Query = {
   lastThreeMonthsAds: Array<Ad>;
   loginProviders: Array<GenerateGoogleAuthUrlResponse>;
   me: User;
+  organization: Organization;
   settingsChannels: Array<IntegrationListItem>;
 };
 
@@ -662,17 +663,23 @@ export type Tokens = {
   token: Scalars['String']['output'];
 };
 
+/** Caller is permitted to view this type if is the user or an admin. Some fields are also permitted if the caller and the user are in a common organization */
 export type User = {
   __typename?: 'User';
   allRoles: Array<AllRoles>;
   createdAt: Scalars['Date']['output'];
   currentOrganization?: Maybe<Organization>;
   currentOrganizationId?: Maybe<Scalars['String']['output']>;
+  /** Caller is permitted to view this field if they are in a common organization */
   email: Scalars['String']['output'];
+  /** Caller is permitted to view this field if they are in a common organization */
   firstName: Scalars['String']['output'];
+  /** Caller is permitted to view this field if they are in a common organization */
   id: Scalars['ID']['output'];
+  /** Caller is permitted to view this field if they are in a common organization */
   lastName: Scalars['String']['output'];
   organizations: Array<UserOrganization>;
+  /** Caller is permitted to view this field if they are in a common organization */
   photoUrl?: Maybe<Scalars['String']['output']>;
   status: UserStatus;
   updatedAt: Scalars['Date']['output'];


### PR DESCRIPTION
## Description

A new query endpoint called `organization` has been created. Among the usual organization fields it also exposes the [userOrganizations](https://github.com/adsviewer/turboviewer/blob/8a8e1de2bb79b5aa191b963a89623eab736c955f/apps/server/src/schema/organization/org-types.ts#L19-L28) that in their turn exposes the [UserDto](https://github.com/adsviewer/turboviewer/blob/e7450b22a774c62a675946e11180898012f1ec03/apps/server/src/schema/user/user-types.ts#L47-L90), that has the crux of the changes. 

- Now userDto had different authScopes. Which means that if you are admin or the caller is the user, gets all the fields just like it was happening till now. 
- But if you are a random user, you won't be able to get any of the fields and the query will return `Not Authorized`
- But (2) if the caller is sharing an organization with the user then you will be able to get the following fields: id, first/last name, email, photoUrl

## Demo/Screenshots (If Applicable)

```
query organization {
  organization {
    id
    userOrganizations {
      userId
      role
      status
      user {
        id
        email
      }
    }
  }
}
```
This query will resolve properly since we are asking for the id + email of users that are members of an organization that the caller is as well.

But this query (added status):
```
query organization {
  organization {
    id
    userOrganizations {
      userId
      role
      status
      user {
        id
        email
        status
      }
    }
  }
}
```
will resolve as "Not Authorized"
