### PR TITLE
fix division deprecation warning

### DIFF
--- a/apps/web/src/components/misc/server-error-page/server-error-page.module.scss
+++ b/apps/web/src/components/misc/server-error-page/server-error-page.module.scss
@@ -1,5 +1,5 @@
 @function rem($px) {
-  @return #{$px / 16}rem;
+  @return #{calc($px / 16)}rem;
 }
 .root {
   padding-top: rem(80px);


### PR DESCRIPTION
## Description

using just `/` will be deprecated in scss in a future release. Either use calc(..) or  math.div(...)
