### PR TITLE
243 migrate insights to use jotai

### DIFF
--- a/apps/web/src/app/(authenticated)/insights/components/group-filters.tsx
+++ b/apps/web/src/app/(authenticated)/insights/components/group-filters.tsx
@@ -16,7 +16,7 @@ import {
   publisherKey,
   accountKey,
 } from '@/util/url-query-utils';
-import { insightsAtom } from '@/app/atoms/insights-atoms';
+import { hasNextInsightsPageAtom, insightsAtom } from '@/app/atoms/insights-atoms';
 import getAccounts from '../../actions';
 
 interface MultiSelectDataType {
@@ -27,6 +27,7 @@ interface MultiSelectDataType {
 export default function GroupFilters(): ReactNode {
   const t = useTranslations('insights.filters');
   const setInsights = useSetAtom(insightsAtom);
+  const setHasNextInsightsPageAtom = useSetAtom(hasNextInsightsPageAtom);
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
@@ -56,6 +57,7 @@ export default function GroupFilters(): ReactNode {
 
   const resetInsights = (): void => {
     setInsights([]);
+    setHasNextInsightsPageAtom(false);
   };
 
   const populateAccountsAvailableValues = (): MultiSelectDataType[] => {

--- a/apps/web/src/app/(authenticated)/insights/components/group-filters.tsx
+++ b/apps/web/src/app/(authenticated)/insights/components/group-filters.tsx
@@ -4,6 +4,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { useTransition } from 'react';
 import { sentenceCase } from 'change-case';
+import { useSetAtom } from 'jotai/index';
 import { DeviceEnum, InsightsColumnsGroupBy, PublisherEnum } from '@/graphql/generated/schema-server';
 import {
   addOrReplaceURLParams,
@@ -15,6 +16,7 @@ import {
   publisherKey,
   accountKey,
 } from '@/util/url-query-utils';
+import { insightsAtom } from '@/app/atoms/insights-atoms';
 import getAccounts from '../../actions';
 
 interface MultiSelectDataType {
@@ -24,6 +26,7 @@ interface MultiSelectDataType {
 
 export default function GroupFilters(): ReactNode {
   const t = useTranslations('insights.filters');
+  const setInsights = useSetAtom(insightsAtom);
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
@@ -50,6 +53,10 @@ export default function GroupFilters(): ReactNode {
       setAccounts(adAccounts);
     });
   }, []);
+
+  const resetInsights = (): void => {
+    setInsights([]);
+  };
 
   const populateAccountsAvailableValues = (): MultiSelectDataType[] => {
     let data: MultiSelectDataType[] = [];
@@ -135,12 +142,14 @@ export default function GroupFilters(): ReactNode {
 
   // Generic functions for handling changes in multi-dropdowns
   const handleMultiFilterAdd = (key: string, value: string): void => {
+    resetInsights();
     startTransition(() => {
       router.replace(addOrReplaceURLParams(pathname, searchParams, key, value));
     });
   };
 
   const handleMultiFilterRemove = (key: string, value: string): void => {
+    resetInsights();
     startTransition(() => {
       router.replace(addOrReplaceURLParams(pathname, searchParams, key, value));
     });
@@ -148,6 +157,7 @@ export default function GroupFilters(): ReactNode {
 
   // Checkboxes logic //
   const handleCheckboxFilter = (e: ChangeEvent<HTMLInputElement>): void => {
+    resetInsights();
     startTransition(() => {
       const isChecked = e.target.checked;
 

--- a/apps/web/src/app/(authenticated)/insights/components/insights-grid.tsx
+++ b/apps/web/src/app/(authenticated)/insights/components/insights-grid.tsx
@@ -3,17 +3,18 @@
 import { Text, SimpleGrid } from '@mantine/core';
 import { type Key, type ReactNode } from 'react';
 import { useTranslations } from 'next-intl';
-import { type InsightsQuery } from '@/graphql/generated/schema-server';
+import { useAtomValue } from 'jotai/index';
 import LoaderCentered from '@/components/misc/loader-centered';
+import { insightsAtom } from '@/app/atoms/insights-atoms';
 import InsightCard from './insight-card';
 
 interface PropsType {
-  insights: InsightsQuery['insights']['edges'];
   isDataLoaded: boolean;
 }
 
 export default function InsightsGrid(props: PropsType): ReactNode {
   const t = useTranslations('insights');
+  const insights = useAtomValue(insightsAtom);
 
   return (
     <>
@@ -21,12 +22,12 @@ export default function InsightsGrid(props: PropsType): ReactNode {
       {!props.isDataLoaded ? <LoaderCentered type="dots" /> : null}
 
       {/* Empty insights data */}
-      {props.isDataLoaded && !props.insights.length ? <Text>{t('noResultsFound')}</Text> : null}
+      {props.isDataLoaded && !insights.length ? <Text>{t('noResultsFound')}</Text> : null}
 
       {/* Render insights */}
       <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} style={{ display: 'relative' }}>
-        {props.insights.length
-          ? props.insights.map((insight) => (
+        {insights.length
+          ? insights.map((insight) => (
               <InsightCard
                 key={insight.id as Key}
                 title={insight.adName ?? insight.publisher ?? t('insight')}

--- a/apps/web/src/app/(authenticated)/insights/components/order-filters.tsx
+++ b/apps/web/src/app/(authenticated)/insights/components/order-filters.tsx
@@ -4,6 +4,7 @@ import { Flex, Text, Select, type ComboboxItem, Switch, Tooltip } from '@mantine
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { type ChangeEvent, useTransition } from 'react';
+import { useSetAtom } from 'jotai/index';
 import {
   OrderDirection,
   addOrReplaceURLParams,
@@ -15,6 +16,7 @@ import {
   groupedByKey,
 } from '@/util/url-query-utils';
 import { InsightsColumnsGroupBy, InsightsColumnsOrderBy } from '@/graphql/generated/schema-server';
+import { insightsAtom } from '@/app/atoms/insights-atoms';
 
 export default function OrderFilters(): React.ReactNode {
   const t = useTranslations('insights');
@@ -22,6 +24,11 @@ export default function OrderFilters(): React.ReactNode {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
+  const setInsights = useSetAtom(insightsAtom);
+
+  const resetInsights = (): void => {
+    setInsights([]);
+  };
 
   const getPageSizeValue = (): string => {
     if (isParamInSearchParams(searchParams, pageSizeKey, searchParams.get(pageSizeKey) ?? '12')) {
@@ -51,6 +58,7 @@ export default function OrderFilters(): React.ReactNode {
   };
 
   const handlePageSizeChange = (value: string | null, option: ComboboxItem): void => {
+    resetInsights();
     const newURL = addOrReplaceURLParams(pathname, searchParams, pageSizeKey, option.value);
     startTransition(() => {
       router.replace(newURL);
@@ -58,6 +66,7 @@ export default function OrderFilters(): React.ReactNode {
   };
 
   const handleOrderByChange = (value: string | null, option: ComboboxItem): void => {
+    resetInsights();
     const newURL = addOrReplaceURLParams(pathname, searchParams, orderByKey, option.value);
     startTransition(() => {
       router.replace(newURL);
@@ -65,6 +74,7 @@ export default function OrderFilters(): React.ReactNode {
   };
 
   const handleOrderDirectionChange = (value: string | null, option: ComboboxItem): void => {
+    resetInsights();
     const newURL = addOrReplaceURLParams(pathname, searchParams, orderDirectionKey, option.value);
     startTransition(() => {
       router.replace(newURL);
@@ -72,6 +82,7 @@ export default function OrderFilters(): React.ReactNode {
   };
 
   const handleAdPreviewChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    resetInsights();
     let newURL: string;
     if (e.target.checked) {
       newURL = addOrReplaceURLParams(pathname, searchParams, fetchPreviewsKey, 'true');

--- a/apps/web/src/app/(authenticated)/insights/components/order-filters.tsx
+++ b/apps/web/src/app/(authenticated)/insights/components/order-filters.tsx
@@ -16,7 +16,7 @@ import {
   groupedByKey,
 } from '@/util/url-query-utils';
 import { InsightsColumnsGroupBy, InsightsColumnsOrderBy } from '@/graphql/generated/schema-server';
-import { insightsAtom } from '@/app/atoms/insights-atoms';
+import { hasNextInsightsPageAtom, insightsAtom } from '@/app/atoms/insights-atoms';
 
 export default function OrderFilters(): React.ReactNode {
   const t = useTranslations('insights');
@@ -25,9 +25,11 @@ export default function OrderFilters(): React.ReactNode {
   const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
   const setInsights = useSetAtom(insightsAtom);
+  const setHasNextInsightsPageAtom = useSetAtom(hasNextInsightsPageAtom);
 
   const resetInsights = (): void => {
     setInsights([]);
+    setHasNextInsightsPageAtom(false);
   };
 
   const getPageSizeValue = (): string => {

--- a/apps/web/src/app/(authenticated)/insights/components/page-controls.tsx
+++ b/apps/web/src/app/(authenticated)/insights/components/page-controls.tsx
@@ -5,17 +5,16 @@ import { IconArrowLeft, IconArrowRight } from '@tabler/icons-react';
 import { useTranslations } from 'next-intl';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import React from 'react';
+import { useAtomValue } from 'jotai/index';
 import { addOrReplaceURLParams, pageKey } from '@/util/url-query-utils';
+import { hasNextInsightsPageAtom } from '@/app/atoms/insights-atoms';
 
-interface PropsType {
-  hasNextPage: boolean;
-}
-
-export default function PageControls(props: PropsType): React.ReactNode {
+export default function PageControls(): React.ReactNode {
   const t = useTranslations('insights');
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const router = useRouter();
+  const hasNextInsightsPage = useAtomValue(hasNextInsightsPageAtom);
 
   const handlePageChange = (type: 'next' | 'prev'): void => {
     if (type === 'next') {
@@ -40,7 +39,7 @@ export default function PageControls(props: PropsType): React.ReactNode {
         {t('prevPage')}
       </Button>
       <Button
-        disabled={!props.hasNextPage}
+        disabled={!hasNextInsightsPage}
         rightSection={<IconArrowRight size={14} />}
         variant="default"
         onClick={() => {

--- a/apps/web/src/app/(authenticated)/insights/components/page-controls.tsx
+++ b/apps/web/src/app/(authenticated)/insights/components/page-controls.tsx
@@ -5,18 +5,25 @@ import { IconArrowLeft, IconArrowRight } from '@tabler/icons-react';
 import { useTranslations } from 'next-intl';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import React from 'react';
-import { useAtomValue } from 'jotai/index';
+import { useSetAtom, useAtom } from 'jotai/index';
 import { addOrReplaceURLParams, pageKey } from '@/util/url-query-utils';
-import { hasNextInsightsPageAtom } from '@/app/atoms/insights-atoms';
+import { hasNextInsightsPageAtom, insightsAtom } from '@/app/atoms/insights-atoms';
 
 export default function PageControls(): React.ReactNode {
   const t = useTranslations('insights');
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const router = useRouter();
-  const hasNextInsightsPage = useAtomValue(hasNextInsightsPageAtom);
+  const setInsights = useSetAtom(insightsAtom);
+  const [hasNextInsightsPage, setHasNextInsightsPageAtom] = useAtom(hasNextInsightsPageAtom);
+
+  const resetInsights = (): void => {
+    setInsights([]);
+    setHasNextInsightsPageAtom(false);
+  };
 
   const handlePageChange = (type: 'next' | 'prev'): void => {
+    resetInsights();
     if (type === 'next') {
       const nextPage = String(Number(searchParams.get(pageKey) ?? '1') + 1);
       router.replace(addOrReplaceURLParams(pathname, searchParams, pageKey, nextPage));

--- a/apps/web/src/app/(authenticated)/insights/page.tsx
+++ b/apps/web/src/app/(authenticated)/insights/page.tsx
@@ -7,7 +7,7 @@ import { useSetAtom } from 'jotai';
 import { InsightsColumnsOrderBy, OrderBy } from '@/graphql/generated/schema-server';
 import LoaderCentered from '@/components/misc/loader-centered';
 import getInsights, { type SearchParams } from '@/app/(authenticated)/insights/actions';
-import { insightsAtom } from '@/app/atoms/insights-atoms';
+import { hasNextInsightsPageAtom, insightsAtom } from '@/app/atoms/insights-atoms';
 import InsightsGrid from './components/insights-grid';
 import OrderFilters from './components/order-filters';
 import PageControls from './components/page-controls';
@@ -22,7 +22,7 @@ export default function Insights({ searchParams }: InsightsProps): ReactNode {
   const pageSize = parseInt(searchParams.pageSize ?? '12', 10);
   const page = parseInt(searchParams.page ?? '1', 10);
   const setInsights = useSetAtom(insightsAtom);
-  const [hasNextPage, setHasNextPage] = useState<boolean>(false);
+  const setHasNextInsightsPage = useSetAtom(hasNextInsightsPageAtom);
   const [isDataLoaded, setIsDataLoaded] = useState<boolean>(false);
 
   useEffect(() => {
@@ -31,13 +31,13 @@ export default function Insights({ searchParams }: InsightsProps): ReactNode {
     void getInsights(searchParams, orderBy, order, pageSize, page)
       .then((res) => {
         setInsights(res.insights.edges);
-        setHasNextPage(res.insights.hasNext);
+        setHasNextInsightsPage(res.insights.hasNext);
         setIsDataLoaded(true);
       })
       .catch((error: unknown) => {
         logger.error(error);
       });
-  }, [order, orderBy, page, pageSize, searchParams, setInsights]);
+  }, [order, orderBy, page, pageSize, searchParams, setHasNextInsightsPage, setInsights]);
 
   return (
     <Box pos="relative">
@@ -45,7 +45,7 @@ export default function Insights({ searchParams }: InsightsProps): ReactNode {
       <Suspense fallback={<LoaderCentered type="dots" />}>
         <Flex direction="column">
           <InsightsGrid isDataLoaded={isDataLoaded} />
-          <PageControls hasNextPage={hasNextPage} />
+          <PageControls />
         </Flex>
       </Suspense>
     </Box>

--- a/apps/web/src/app/(authenticated)/insights/page.tsx
+++ b/apps/web/src/app/(authenticated)/insights/page.tsx
@@ -3,9 +3,11 @@
 import { type ReactNode, Suspense, useEffect, useState } from 'react';
 import { Box, Flex } from '@mantine/core';
 import { logger } from '@repo/logger';
-import { InsightsColumnsOrderBy, type InsightsQuery, OrderBy } from '@/graphql/generated/schema-server';
+import { useSetAtom } from 'jotai';
+import { InsightsColumnsOrderBy, OrderBy } from '@/graphql/generated/schema-server';
 import LoaderCentered from '@/components/misc/loader-centered';
 import getInsights, { type SearchParams } from '@/app/(authenticated)/insights/actions';
+import { insightsAtom } from '@/app/atoms/insights-atoms';
 import InsightsGrid from './components/insights-grid';
 import OrderFilters from './components/order-filters';
 import PageControls from './components/page-controls';
@@ -19,7 +21,7 @@ export default function Insights({ searchParams }: InsightsProps): ReactNode {
   const order = searchParams.order ?? OrderBy.desc;
   const pageSize = parseInt(searchParams.pageSize ?? '12', 10);
   const page = parseInt(searchParams.page ?? '1', 10);
-  const [insights, setInsights] = useState<InsightsQuery['insights']['edges']>([]);
+  const setInsights = useSetAtom(insightsAtom);
   const [hasNextPage, setHasNextPage] = useState<boolean>(false);
   const [isDataLoaded, setIsDataLoaded] = useState<boolean>(false);
 
@@ -35,14 +37,14 @@ export default function Insights({ searchParams }: InsightsProps): ReactNode {
       .catch((error: unknown) => {
         logger.error(error);
       });
-  }, [order, orderBy, page, pageSize, searchParams]);
+  }, [order, orderBy, page, pageSize, searchParams, setInsights]);
 
   return (
     <Box pos="relative">
       <OrderFilters />
       <Suspense fallback={<LoaderCentered type="dots" />}>
         <Flex direction="column">
-          <InsightsGrid insights={insights} isDataLoaded={isDataLoaded} />
+          <InsightsGrid isDataLoaded={isDataLoaded} />
           <PageControls hasNextPage={hasNextPage} />
         </Flex>
       </Suspense>

--- a/apps/web/src/app/atoms/insights-atoms.ts
+++ b/apps/web/src/app/atoms/insights-atoms.ts
@@ -1,0 +1,4 @@
+import { atom } from 'jotai';
+import { type InsightsQuery } from '@/graphql/generated/schema-server';
+
+export const insightsAtom = atom<InsightsQuery['insights']['edges']>([]);

--- a/apps/web/src/app/atoms/insights-atoms.ts
+++ b/apps/web/src/app/atoms/insights-atoms.ts
@@ -2,3 +2,4 @@ import { atom } from 'jotai';
 import { type InsightsQuery } from '@/graphql/generated/schema-server';
 
 export const insightsAtom = atom<InsightsQuery['insights']['edges']>([]);
+export const hasNextInsightsPageAtom = atom<boolean>(false);


### PR DESCRIPTION
Insights now use Jotai to better handle their state changes independent of the URL, while still utilizing the URL for filters.
As a result, changing filters is more responsive to user input, since they reset the fetched insights to empty and show a loading state before finishing the request of the new insights.

This will also improve much more when we look into integrating the dedicated animations library. 