### PR TITLE
introduce removeUserFromOrganization

### DIFF
--- a/apps/server/src/contexts/login-provider/login-provider-helper.ts
+++ b/apps/server/src/contexts/login-provider/login-provider-helper.ts
@@ -105,7 +105,10 @@ const handleInvitedUserCase = async (
     }),
     prisma.userOrganization.update({
       where: { userId_organizationId: { userId: user.id, organizationId } },
-      data: { status: UserOrganizationStatus.ACTIVE },
+      data: {
+        status: UserOrganizationStatus.ACTIVE,
+        user: { update: { currentOrganizationId: organizationId } },
+      },
     }),
     redisDel(confirmInvitedUserRedisKey(token)),
   ]);

--- a/apps/server/src/contexts/user/user.ts
+++ b/apps/server/src/contexts/user/user.ts
@@ -215,7 +215,7 @@ const completeConfirmInvitedUserCallback = async (token: string): Promise<Tokens
   await Promise.all([
     prisma.userOrganization.update({
       where: { userId_organizationId: { userId, organizationId } },
-      data: { status: UserOrganizationStatus.ACTIVE },
+      data: { status: UserOrganizationStatus.ACTIVE, user: { update: { currentOrganizationId: organizationId } } },
     }),
     redisDel(key),
   ]);

--- a/apps/server/src/schema/builder.ts
+++ b/apps/server/src/schema/builder.ts
@@ -10,7 +10,6 @@ import ScopeAuthPlugin from '@pothos/plugin-scope-auth';
 import SimpleObjectsPlugin from '@pothos/plugin-simple-objects';
 import ValidationPlugin from '@pothos/plugin-validation';
 import { prisma, Prisma } from '@repo/database';
-import { AError } from '@repo/utils';
 import { type GraphQLContext } from '../context';
 import { getRootOrganizationId } from '../contexts/organization';
 import JsonValue = Prisma.JsonValue;
@@ -68,7 +67,7 @@ export const builder = new SchemaBuilder<{
 }>({
   plugins: [ErrorsPlugin, RelayPlugin, ScopeAuthPlugin, PrismaPlugin, SimpleObjectsPlugin, ValidationPlugin],
   errorOptions: {
-    defaultTypes: [AError],
+    defaultTypes: [],
   },
   relayOptions: {
     // These will become the defaults in the next major version

--- a/apps/server/src/schema/generated/schema.graphql
+++ b/apps/server/src/schema/generated/schema.graphql
@@ -524,6 +524,7 @@ type Mutation {
   inviteUsers(emails: [String!]!, role: OrganizationRoleEnum!): [InviteUsersResponse!]!
   login(email: String!, password: String!, token: String): Tokens!
   refreshData(initial: Boolean!, integrationIds: [String!]): Boolean!
+  removeUserFromOrganization(userId: String!): UserOrganization!
   resendEmailConfirmation: Boolean!
   resetPassword(password: String!, token: String!): Tokens!
 
@@ -535,11 +536,7 @@ type Mutation {
   switchOrganization(organizationId: String!): Tokens!
   updateOrganization(name: String!): Organization!
   updateOrganizationAdAccounts(adAccountIds: [String!]!): Organization!
-  updateOrganizationUser(
-    role: OrganizationRoleEnum
-    status: UserOrganizationStatusNotInvited
-    userId: String!
-  ): UserOrganization!
+  updateOrganizationUser(role: OrganizationRoleEnum, userId: String!): UserOrganization!
   updateUser(firstName: String, lastName: String, newPassword: String, oldPassword: String): User!
 }
 
@@ -720,13 +717,7 @@ type UserOrganization {
 
 enum UserOrganizationStatus {
   ACTIVE
-  NON_ACTIVE
   INVITED
-}
-
-enum UserOrganizationStatusNotInvited {
-  ACTIVE
-  NON_ACTIVE
 }
 
 enum UserStatus {

--- a/apps/server/src/schema/generated/schema.graphql
+++ b/apps/server/src/schema/generated/schema.graphql
@@ -260,11 +260,6 @@ enum DeviceEnum {
   Unknown
 }
 
-enum EmailType {
-  PERSONAL
-  WORK
-}
-
 interface Error {
   message: String!
 }
@@ -481,9 +476,14 @@ type InviteLinks {
   url: String!
 }
 
-type InviteUsersResponse {
+type InviteUsersError {
   email: String!
-  errorMessage: String!
+  message: String!
+}
+
+type InviteUsersErrors implements Error {
+  errors: [InviteUsersError!]!
+  message: String!
 }
 
 """
@@ -521,7 +521,7 @@ type Mutation {
   deleteInvitationLink(role: OrganizationRoleEnum!): Boolean!
   deleteOrganization(organizationId: String): Organization!
   forgetPassword(email: String!): Boolean!
-  inviteUsers(emails: [String!]!, role: OrganizationRoleEnum!): [InviteUsersResponse!]!
+  inviteUsers(emails: [String!]!, role: OrganizationRoleEnum!): MutationInviteUsersResult!
   login(email: String!, password: String!, token: String): Tokens!
   refreshData(initial: Boolean!, integrationIds: [String!]): Boolean!
   removeUserFromOrganization(userId: String!): UserOrganization!
@@ -544,6 +544,12 @@ union MutationDeAuthIntegrationResult = BaseError | MetaError | MutationDeAuthIn
 
 type MutationDeAuthIntegrationSuccess {
   data: String!
+}
+
+union MutationInviteUsersResult = InviteUsersErrors | MutationInviteUsersSuccess
+
+type MutationInviteUsersSuccess {
+  data: Boolean!
 }
 
 enum OrderBy {

--- a/apps/server/src/schema/organization/org-types.ts
+++ b/apps/server/src/schema/organization/org-types.ts
@@ -41,14 +41,6 @@ export const OrganizationRoleEnumDto = builder.enumType('OrganizationRoleEnum', 
 });
 export const UserOrganizationStatusDto = builder.enumType(UserOrganizationStatus, { name: 'UserOrganizationStatus' });
 
-export const UserOrganizationStatusNotInvitedDto = builder.enumType('UserOrganizationStatusNotInvited', {
-  values: Object.fromEntries(
-    Object.entries(UserOrganizationStatus)
-      .filter(([_, value]) => value !== UserOrganizationStatus.INVITED)
-      .map(([name, value]) => [name, { value }]),
-  ),
-});
-
 export const UserOrganizationDto = builder.prismaObject('UserOrganization', {
   fields: (t) => ({
     userId: t.exposeID('userId'),

--- a/apps/server/src/schema/organization/org-types.ts
+++ b/apps/server/src/schema/organization/org-types.ts
@@ -1,5 +1,7 @@
-import { EmailType, OrganizationRoleEnum, UserOrganizationStatus } from '@repo/database';
+import { OrganizationRoleEnum, UserOrganizationStatus } from '@repo/database';
+import { AError } from '@repo/utils';
 import { builder } from '../builder';
+import { ErrorInterface } from '../errors';
 
 export const OrganizationDto = builder.prismaObject('Organization', {
   authScopes: (organization, ctx) => {
@@ -52,14 +54,30 @@ export const UserOrganizationDto = builder.prismaObject('UserOrganization', {
   }),
 });
 
-export const InviteUserRespDto = builder.simpleObject('InviteUsersResponse', {
+export class InviteUsersErrors extends AError {
+  errors: { email: string; message: string }[];
+
+  constructor(errors: { email: string; message: string }[]) {
+    super('Some users were not invited');
+    this.errors = errors;
+    this.name = 'InviteUsersErrors';
+  }
+}
+
+export const InviteUsersErrorDto = builder.simpleObject('InviteUsersError', {
   fields: (t) => ({
     email: t.string({ nullable: false }),
-    errorMessage: t.string({ nullable: false }),
+    message: t.string({ nullable: false }),
   }),
 });
 
-export const EmailTypeDto = builder.enumType(EmailType, { name: 'EmailType' });
+export const InviteUsersErrorsDto = builder.objectType(InviteUsersErrors, {
+  name: 'InviteUsersErrors',
+  interfaces: [ErrorInterface],
+  fields: (t) => ({
+    errors: t.expose('errors', { type: [InviteUsersErrorDto], nullable: false }),
+  }),
+});
 
 export const inviteLinkDto = builder.simpleObject('InviteLinks', {
   fields: (t) => ({

--- a/apps/server/src/schema/organization/organization-operations.ts
+++ b/apps/server/src/schema/organization/organization-operations.ts
@@ -32,7 +32,6 @@ import {
   OrganizationDto,
   OrganizationRoleEnumDto,
   UserOrganizationDto,
-  UserOrganizationStatusNotInvitedDto,
 } from './org-types';
 
 const fireAndForget = new FireAndForget();
@@ -380,10 +379,46 @@ builder.mutationFields((t) => ({
     },
   }),
 
+  removeUserFromOrganization: t.withAuth({ isOrgAdmin: true, isOrgOperator: true }).field({
+    type: UserOrganizationDto,
+    args: {
+      userId: t.arg.string({ required: true }),
+    },
+    resolve: async (_root, args, ctx, _info) => {
+      const userOrganization = await prisma.userOrganization.findUnique({
+        where: {
+          userId_organizationId: { userId: args.userId, organizationId: ctx.organizationId },
+          status: UserOrganizationStatus.ACTIVE,
+        },
+      });
+      if (!userOrganization) {
+        throw new GraphQLError('User is not an active member of this organization');
+      }
+      if (ctx.isOrgOperator && userOrganization.role === OrganizationRoleEnum.ORG_ADMIN) {
+        throw new GraphQLError('Only organization administrators can remove organization administrators');
+      }
+      if (ctx.currentUserId === args.userId && ctx.isOrgAdmin) {
+        const otherAdmins = await prisma.userOrganization.count({
+          where: {
+            organizationId: ctx.organizationId,
+            userId: { not: ctx.currentUserId },
+            role: OrganizationRoleEnum.ORG_ADMIN,
+            status: UserOrganizationStatus.ACTIVE,
+          },
+        });
+        if (otherAdmins === 0) {
+          throw new GraphQLError('Cannot remove the last organization administrator');
+        }
+      }
+      return prisma.userOrganization.delete({
+        where: { userId_organizationId: { userId: args.userId, organizationId: ctx.organizationId } },
+      });
+    },
+  }),
+
   updateOrganizationUser: t.withAuth({ isOrgAdmin: true, isOrgOperator: true }).field({
     type: UserOrganizationDto,
     args: {
-      status: t.arg({ type: UserOrganizationStatusNotInvitedDto, required: false }),
       role: t.arg({ type: OrganizationRoleEnumDto, required: false }),
       userId: t.arg.string({ required: true }),
     },
@@ -400,23 +435,9 @@ builder.mutationFields((t) => ({
       if (ctx.isOrgOperator && userOrganization.role === OrganizationRoleEnum.ORG_ADMIN) {
         throw new GraphQLError('Only organization administrators can update organization administrators');
       }
-      if (ctx.currentUserId === args.userId && ctx.isOrgAdmin && args.status === UserOrganizationStatus.NON_ACTIVE) {
-        const otherAdmins = await prisma.userOrganization.count({
-          where: {
-            organizationId: ctx.organizationId,
-            userId: { not: ctx.currentUserId },
-            role: OrganizationRoleEnum.ORG_ADMIN,
-            status: UserOrganizationStatus.ACTIVE,
-          },
-        });
-        if (otherAdmins === 0) {
-          throw new GraphQLError('Cannot remove the last organization administrator');
-        }
-      }
       return prisma.userOrganization.update({
         where: { userId_organizationId: { userId: args.userId, organizationId: ctx.organizationId } },
         data: {
-          status: args.status ?? undefined,
           role: args.role ?? undefined,
         },
       });

--- a/apps/server/src/schema/user/invite-operations.ts
+++ b/apps/server/src/schema/user/invite-operations.ts
@@ -54,7 +54,7 @@ builder.mutationFields((t) => ({
         }),
         prisma.userOrganization.update({
           where: { userId_organizationId: { userId, organizationId } },
-          data: { status: UserOrganizationStatus.ACTIVE },
+          data: { status: UserOrganizationStatus.ACTIVE, user: { update: { currentOrganizationId: organizationId } } },
         }),
         redisDel(key),
       ]);

--- a/apps/web-old/src/graphql/generated/schema-client.ts
+++ b/apps/web-old/src/graphql/generated/schema-client.ts
@@ -526,6 +526,7 @@ export type Mutation = {
   inviteUsers: Array<InviteUsersResponse>;
   login: Tokens;
   refreshData: Scalars['Boolean']['output'];
+  removeUserFromOrganization: UserOrganization;
   resendEmailConfirmation: Scalars['Boolean']['output'];
   resetPassword: Tokens;
   /** Use this mutation after the user has clicked on the personalized invite link on their email and they don't have an account yet */
@@ -582,6 +583,10 @@ export type MutationRefreshDataArgs = {
   integrationIds?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
+export type MutationRemoveUserFromOrganizationArgs = {
+  userId: Scalars['String']['input'];
+};
+
 export type MutationResetPasswordArgs = {
   password: Scalars['String']['input'];
   token: Scalars['String']['input'];
@@ -612,7 +617,6 @@ export type MutationUpdateOrganizationAdAccountsArgs = {
 
 export type MutationUpdateOrganizationUserArgs = {
   role?: InputMaybe<OrganizationRoleEnum>;
-  status?: InputMaybe<UserOrganizationStatusNotInvited>;
   userId: Scalars['String']['input'];
 };
 
@@ -809,13 +813,7 @@ export type UserOrganization = {
 
 export enum UserOrganizationStatus {
   ACTIVE = 'ACTIVE',
-  NON_ACTIVE = 'NON_ACTIVE',
   INVITED = 'INVITED',
-}
-
-export enum UserOrganizationStatusNotInvited {
-  ACTIVE = 'ACTIVE',
-  NON_ACTIVE = 'NON_ACTIVE',
 }
 
 export enum UserStatus {

--- a/apps/web-old/src/graphql/generated/schema-client.ts
+++ b/apps/web-old/src/graphql/generated/schema-client.ts
@@ -292,11 +292,6 @@ export enum DeviceEnum {
   Unknown = 'Unknown',
 }
 
-export enum EmailType {
-  PERSONAL = 'PERSONAL',
-  WORK = 'WORK',
-}
-
 export type Error = {
   message: Scalars['String']['output'];
 };
@@ -493,10 +488,16 @@ export type InviteLinks = {
   url: Scalars['String']['output'];
 };
 
-export type InviteUsersResponse = {
-  __typename?: 'InviteUsersResponse';
+export type InviteUsersError = {
+  __typename?: 'InviteUsersError';
   email: Scalars['String']['output'];
-  errorMessage: Scalars['String']['output'];
+  message: Scalars['String']['output'];
+};
+
+export type InviteUsersErrors = Error & {
+  __typename?: 'InviteUsersErrors';
+  errors: Array<InviteUsersError>;
+  message: Scalars['String']['output'];
 };
 
 export enum LoginProviderEnum {
@@ -523,7 +524,7 @@ export type Mutation = {
   deleteInvitationLink: Scalars['Boolean']['output'];
   deleteOrganization: Organization;
   forgetPassword: Scalars['Boolean']['output'];
-  inviteUsers: Array<InviteUsersResponse>;
+  inviteUsers: MutationInviteUsersResult;
   login: Tokens;
   refreshData: Scalars['Boolean']['output'];
   removeUserFromOrganization: UserOrganization;
@@ -632,6 +633,13 @@ export type MutationDeAuthIntegrationResult = BaseError | MetaError | MutationDe
 export type MutationDeAuthIntegrationSuccess = {
   __typename?: 'MutationDeAuthIntegrationSuccess';
   data: Scalars['String']['output'];
+};
+
+export type MutationInviteUsersResult = InviteUsersErrors | MutationInviteUsersSuccess;
+
+export type MutationInviteUsersSuccess = {
+  __typename?: 'MutationInviteUsersSuccess';
+  data: Scalars['Boolean']['output'];
 };
 
 export enum OrderBy {

--- a/apps/web-old/src/graphql/generated/schema-server.ts
+++ b/apps/web-old/src/graphql/generated/schema-server.ts
@@ -525,6 +525,7 @@ export type Mutation = {
   inviteUsers: Array<InviteUsersResponse>;
   login: Tokens;
   refreshData: Scalars['Boolean']['output'];
+  removeUserFromOrganization: UserOrganization;
   resendEmailConfirmation: Scalars['Boolean']['output'];
   resetPassword: Tokens;
   /** Use this mutation after the user has clicked on the personalized invite link on their email and they don't have an account yet */
@@ -581,6 +582,10 @@ export type MutationRefreshDataArgs = {
   integrationIds?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
+export type MutationRemoveUserFromOrganizationArgs = {
+  userId: Scalars['String']['input'];
+};
+
 export type MutationResetPasswordArgs = {
   password: Scalars['String']['input'];
   token: Scalars['String']['input'];
@@ -611,7 +616,6 @@ export type MutationUpdateOrganizationAdAccountsArgs = {
 
 export type MutationUpdateOrganizationUserArgs = {
   role?: InputMaybe<OrganizationRoleEnum>;
-  status?: InputMaybe<UserOrganizationStatusNotInvited>;
   userId: Scalars['String']['input'];
 };
 
@@ -808,13 +812,7 @@ export type UserOrganization = {
 
 export enum UserOrganizationStatus {
   ACTIVE = 'ACTIVE',
-  NON_ACTIVE = 'NON_ACTIVE',
   INVITED = 'INVITED',
-}
-
-export enum UserOrganizationStatusNotInvited {
-  ACTIVE = 'ACTIVE',
-  NON_ACTIVE = 'NON_ACTIVE',
 }
 
 export enum UserStatus {

--- a/apps/web-old/src/graphql/generated/schema-server.ts
+++ b/apps/web-old/src/graphql/generated/schema-server.ts
@@ -291,11 +291,6 @@ export enum DeviceEnum {
   Unknown = 'Unknown',
 }
 
-export enum EmailType {
-  PERSONAL = 'PERSONAL',
-  WORK = 'WORK',
-}
-
 export type Error = {
   message: Scalars['String']['output'];
 };
@@ -492,10 +487,16 @@ export type InviteLinks = {
   url: Scalars['String']['output'];
 };
 
-export type InviteUsersResponse = {
-  __typename?: 'InviteUsersResponse';
+export type InviteUsersError = {
+  __typename?: 'InviteUsersError';
   email: Scalars['String']['output'];
-  errorMessage: Scalars['String']['output'];
+  message: Scalars['String']['output'];
+};
+
+export type InviteUsersErrors = Error & {
+  __typename?: 'InviteUsersErrors';
+  errors: Array<InviteUsersError>;
+  message: Scalars['String']['output'];
 };
 
 export enum LoginProviderEnum {
@@ -522,7 +523,7 @@ export type Mutation = {
   deleteInvitationLink: Scalars['Boolean']['output'];
   deleteOrganization: Organization;
   forgetPassword: Scalars['Boolean']['output'];
-  inviteUsers: Array<InviteUsersResponse>;
+  inviteUsers: MutationInviteUsersResult;
   login: Tokens;
   refreshData: Scalars['Boolean']['output'];
   removeUserFromOrganization: UserOrganization;
@@ -631,6 +632,13 @@ export type MutationDeAuthIntegrationResult = BaseError | MetaError | MutationDe
 export type MutationDeAuthIntegrationSuccess = {
   __typename?: 'MutationDeAuthIntegrationSuccess';
   data: Scalars['String']['output'];
+};
+
+export type MutationInviteUsersResult = InviteUsersErrors | MutationInviteUsersSuccess;
+
+export type MutationInviteUsersSuccess = {
+  __typename?: 'MutationInviteUsersSuccess';
+  data: Scalars['Boolean']['output'];
 };
 
 export enum OrderBy {

--- a/apps/web/src/graphql/generated/schema-client.ts
+++ b/apps/web/src/graphql/generated/schema-client.ts
@@ -526,6 +526,7 @@ export type Mutation = {
   inviteUsers: Array<InviteUsersResponse>;
   login: Tokens;
   refreshData: Scalars['Boolean']['output'];
+  removeUserFromOrganization: UserOrganization;
   resendEmailConfirmation: Scalars['Boolean']['output'];
   resetPassword: Tokens;
   /** Use this mutation after the user has clicked on the personalized invite link on their email and they don't have an account yet */
@@ -582,6 +583,10 @@ export type MutationRefreshDataArgs = {
   integrationIds?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
+export type MutationRemoveUserFromOrganizationArgs = {
+  userId: Scalars['String']['input'];
+};
+
 export type MutationResetPasswordArgs = {
   password: Scalars['String']['input'];
   token: Scalars['String']['input'];
@@ -612,7 +617,6 @@ export type MutationUpdateOrganizationAdAccountsArgs = {
 
 export type MutationUpdateOrganizationUserArgs = {
   role?: InputMaybe<OrganizationRoleEnum>;
-  status?: InputMaybe<UserOrganizationStatusNotInvited>;
   userId: Scalars['String']['input'];
 };
 
@@ -809,13 +813,7 @@ export type UserOrganization = {
 
 export enum UserOrganizationStatus {
   ACTIVE = 'ACTIVE',
-  NON_ACTIVE = 'NON_ACTIVE',
   INVITED = 'INVITED',
-}
-
-export enum UserOrganizationStatusNotInvited {
-  ACTIVE = 'ACTIVE',
-  NON_ACTIVE = 'NON_ACTIVE',
 }
 
 export enum UserStatus {

--- a/apps/web/src/graphql/generated/schema-client.ts
+++ b/apps/web/src/graphql/generated/schema-client.ts
@@ -292,11 +292,6 @@ export enum DeviceEnum {
   Unknown = 'Unknown',
 }
 
-export enum EmailType {
-  PERSONAL = 'PERSONAL',
-  WORK = 'WORK',
-}
-
 export type Error = {
   message: Scalars['String']['output'];
 };
@@ -493,10 +488,16 @@ export type InviteLinks = {
   url: Scalars['String']['output'];
 };
 
-export type InviteUsersResponse = {
-  __typename?: 'InviteUsersResponse';
+export type InviteUsersError = {
+  __typename?: 'InviteUsersError';
   email: Scalars['String']['output'];
-  errorMessage: Scalars['String']['output'];
+  message: Scalars['String']['output'];
+};
+
+export type InviteUsersErrors = Error & {
+  __typename?: 'InviteUsersErrors';
+  errors: Array<InviteUsersError>;
+  message: Scalars['String']['output'];
 };
 
 export enum LoginProviderEnum {
@@ -523,7 +524,7 @@ export type Mutation = {
   deleteInvitationLink: Scalars['Boolean']['output'];
   deleteOrganization: Organization;
   forgetPassword: Scalars['Boolean']['output'];
-  inviteUsers: Array<InviteUsersResponse>;
+  inviteUsers: MutationInviteUsersResult;
   login: Tokens;
   refreshData: Scalars['Boolean']['output'];
   removeUserFromOrganization: UserOrganization;
@@ -632,6 +633,13 @@ export type MutationDeAuthIntegrationResult = BaseError | MetaError | MutationDe
 export type MutationDeAuthIntegrationSuccess = {
   __typename?: 'MutationDeAuthIntegrationSuccess';
   data: Scalars['String']['output'];
+};
+
+export type MutationInviteUsersResult = InviteUsersErrors | MutationInviteUsersSuccess;
+
+export type MutationInviteUsersSuccess = {
+  __typename?: 'MutationInviteUsersSuccess';
+  data: Scalars['Boolean']['output'];
 };
 
 export enum OrderBy {

--- a/apps/web/src/graphql/generated/schema-server.ts
+++ b/apps/web/src/graphql/generated/schema-server.ts
@@ -525,6 +525,7 @@ export type Mutation = {
   inviteUsers: Array<InviteUsersResponse>;
   login: Tokens;
   refreshData: Scalars['Boolean']['output'];
+  removeUserFromOrganization: UserOrganization;
   resendEmailConfirmation: Scalars['Boolean']['output'];
   resetPassword: Tokens;
   /** Use this mutation after the user has clicked on the personalized invite link on their email and they don't have an account yet */
@@ -581,6 +582,10 @@ export type MutationRefreshDataArgs = {
   integrationIds?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
+export type MutationRemoveUserFromOrganizationArgs = {
+  userId: Scalars['String']['input'];
+};
+
 export type MutationResetPasswordArgs = {
   password: Scalars['String']['input'];
   token: Scalars['String']['input'];
@@ -611,7 +616,6 @@ export type MutationUpdateOrganizationAdAccountsArgs = {
 
 export type MutationUpdateOrganizationUserArgs = {
   role?: InputMaybe<OrganizationRoleEnum>;
-  status?: InputMaybe<UserOrganizationStatusNotInvited>;
   userId: Scalars['String']['input'];
 };
 
@@ -808,13 +812,7 @@ export type UserOrganization = {
 
 export enum UserOrganizationStatus {
   ACTIVE = 'ACTIVE',
-  NON_ACTIVE = 'NON_ACTIVE',
   INVITED = 'INVITED',
-}
-
-export enum UserOrganizationStatusNotInvited {
-  ACTIVE = 'ACTIVE',
-  NON_ACTIVE = 'NON_ACTIVE',
 }
 
 export enum UserStatus {

--- a/apps/web/src/graphql/generated/schema-server.ts
+++ b/apps/web/src/graphql/generated/schema-server.ts
@@ -291,11 +291,6 @@ export enum DeviceEnum {
   Unknown = 'Unknown',
 }
 
-export enum EmailType {
-  PERSONAL = 'PERSONAL',
-  WORK = 'WORK',
-}
-
 export type Error = {
   message: Scalars['String']['output'];
 };
@@ -492,10 +487,16 @@ export type InviteLinks = {
   url: Scalars['String']['output'];
 };
 
-export type InviteUsersResponse = {
-  __typename?: 'InviteUsersResponse';
+export type InviteUsersError = {
+  __typename?: 'InviteUsersError';
   email: Scalars['String']['output'];
-  errorMessage: Scalars['String']['output'];
+  message: Scalars['String']['output'];
+};
+
+export type InviteUsersErrors = Error & {
+  __typename?: 'InviteUsersErrors';
+  errors: Array<InviteUsersError>;
+  message: Scalars['String']['output'];
 };
 
 export enum LoginProviderEnum {
@@ -522,7 +523,7 @@ export type Mutation = {
   deleteInvitationLink: Scalars['Boolean']['output'];
   deleteOrganization: Organization;
   forgetPassword: Scalars['Boolean']['output'];
-  inviteUsers: Array<InviteUsersResponse>;
+  inviteUsers: MutationInviteUsersResult;
   login: Tokens;
   refreshData: Scalars['Boolean']['output'];
   removeUserFromOrganization: UserOrganization;
@@ -631,6 +632,13 @@ export type MutationDeAuthIntegrationResult = BaseError | MetaError | MutationDe
 export type MutationDeAuthIntegrationSuccess = {
   __typename?: 'MutationDeAuthIntegrationSuccess';
   data: Scalars['String']['output'];
+};
+
+export type MutationInviteUsersResult = InviteUsersErrors | MutationInviteUsersSuccess;
+
+export type MutationInviteUsersSuccess = {
+  __typename?: 'MutationInviteUsersSuccess';
+  data: Scalars['Boolean']['output'];
 };
 
 export enum OrderBy {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "turbo test",
     "type-check": "turbo type-check",
     "clean": "turbo clean",
-    "update": "pnpm update --latest && turbo update --concurrency=1 && pnpm install",
+    "update": "pnpm update --latest && pnpm i && turbo update --concurrency=1 && pnpm install",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "prettier": "prettier --check \"**/*.{ts,tsx,md}\"",
     "lint-staged": "lint-staged --no-hide-partially-staged",
@@ -24,7 +24,7 @@
     "prisma": "^5.16.1",
     "terraform": "^1.23.0",
     "tsx": "^4.16.0",
-    "turbo": "^2.0.9"
+    "turbo": "^2.0.11"
   },
   "packageManager": "pnpm@9.6.0",
   "engines": {

--- a/packages/database/prisma/migrations/20240802144457_remove_non_active/migration.sql
+++ b/packages/database/prisma/migrations/20240802144457_remove_non_active/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - The values [NON_ACTIVE] on the enum `UserOrganizationStatus` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "UserOrganizationStatus_new" AS ENUM ('ACTIVE', 'INVITED');
+ALTER TABLE "user_organizations" ALTER COLUMN "status" TYPE "UserOrganizationStatus_new" USING ("status"::text::"UserOrganizationStatus_new");
+ALTER TYPE "UserOrganizationStatus" RENAME TO "UserOrganizationStatus_old";
+ALTER TYPE "UserOrganizationStatus_new" RENAME TO "UserOrganizationStatus";
+DROP TYPE "UserOrganizationStatus_old";
+COMMIT;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -112,7 +112,6 @@ model UserRole {
 
 enum UserOrganizationStatus {
   ACTIVE
-  NON_ACTIVE
   INVITED
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ importers:
         specifier: ^4.16.0
         version: 4.16.0
       turbo:
-        specifier: ^2.0.9
-        version: 2.0.9
+        specifier: ^2.0.11
+        version: 2.0.11
 
   apps/channel-ingress:
     dependencies:
@@ -7980,38 +7980,38 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  turbo-darwin-64@2.0.9:
-    resolution: {integrity: sha512-owlGsOaExuVGBUfrnJwjkL1BWlvefjSKczEAcpLx4BI7Oh6ttakOi+JyomkPkFlYElRpjbvlR2gP8WIn6M/+xQ==}
+  turbo-darwin-64@2.0.11:
+    resolution: {integrity: sha512-YlHEEhcm+jI1BSZoLugGHUWDfRXaNaQIv7tGQBfadYjo9kixBnqoTOU6s1ubOrQMID+lizZZQs79GXwqM6vohg==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.0.9:
-    resolution: {integrity: sha512-XAXkKkePth5ZPPE/9G9tTnPQx0C8UTkGWmNGYkpmGgRr8NedW+HrPsi9N0HcjzzIH9A4TpNYvtiV+WcwdaEjKA==}
+  turbo-darwin-arm64@2.0.11:
+    resolution: {integrity: sha512-K/YW+hWzRQ/wGmtffxllH4M1tgy8OlwgXODrIiAGzkSpZl9+pIsem/F86UULlhsIeavBYK/LS5+dzV3DPMjJ9w==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.0.9:
-    resolution: {integrity: sha512-l9wSgEjrCFM1aG16zItBsZ206ZlhSSx1owB8Cgskfv0XyIXRGHRkluihiaxkp+UeU5WoEfz4EN5toc+ICA0q0w==}
+  turbo-linux-64@2.0.11:
+    resolution: {integrity: sha512-mv8CwGP06UPweMh1Vlp6PI6OWnkuibxfIJ4Vlof7xqjohAaZU5FLqeOeHkjQflH/6YrCVuS9wrK0TFOu+meTtA==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.0.9:
-    resolution: {integrity: sha512-gRnjxXRne18B27SwxXMqL3fJu7jw/8kBrOBTBNRSmZZiG1Uu3nbnP7b4lgrA/bCku6C0Wligwqurvtpq6+nFHA==}
+  turbo-linux-arm64@2.0.11:
+    resolution: {integrity: sha512-wLE5tl4oriTmHbuayc0ki0csaCplmVLj+uCWtecM/mfBuZgNS9ICNM9c4sB+Cfl5tlBBFeepqRNgvRvn8WeVZg==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.0.9:
-    resolution: {integrity: sha512-ZVo0apxUvaRq4Vm1qhsfqKKhtRgReYlBVf9MQvVU1O9AoyydEQvLDO1ryqpXDZWpcHoFxHAQc9msjAMtE5K2lA==}
+  turbo-windows-64@2.0.11:
+    resolution: {integrity: sha512-tja3zvVCSWu3HizOoeQv0qDJ+GeWGWRFOOM6a8i3BYnXLgGKAaDZFcjwzgC50tWiAw4aowIVR4OouwIyRhLBaQ==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.0.9:
-    resolution: {integrity: sha512-sGRz7c5Pey6y7y9OKi8ypbWNuIRPF9y8xcMqL56OZifSUSo+X2EOsOleR9MKxQXVaqHPGOUKWsE6y8hxBi9pag==}
+  turbo-windows-arm64@2.0.11:
+    resolution: {integrity: sha512-sYjXP6k94Bqh99R+y3M1Ks6LRIEZybMz+7enA8GKl6JJ2ZFaXxTnS6q+/2+ii1+rRwxohj5OBb4gxODcF8Jd4w==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.0.9:
-    resolution: {integrity: sha512-QaLaUL1CqblSKKPgLrFW3lZWkWG4pGBQNW+q1ScJB5v1D/nFWtsrD/yZljW/bdawg90ihi4/ftQJ3h6fz1FamA==}
+  turbo@2.0.11:
+    resolution: {integrity: sha512-imDlFFAvitbCm1JtDFJ6eG882qwxHUmVT2noPb3p2jq5o5DuXOchMbkVS9kUeC3/4WpY5N0GBZ3RvqNyjHZw1Q==}
     hasBin: true
 
   type-check@0.4.0:
@@ -16622,32 +16622,32 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  turbo-darwin-64@2.0.9:
+  turbo-darwin-64@2.0.11:
     optional: true
 
-  turbo-darwin-arm64@2.0.9:
+  turbo-darwin-arm64@2.0.11:
     optional: true
 
-  turbo-linux-64@2.0.9:
+  turbo-linux-64@2.0.11:
     optional: true
 
-  turbo-linux-arm64@2.0.9:
+  turbo-linux-arm64@2.0.11:
     optional: true
 
-  turbo-windows-64@2.0.9:
+  turbo-windows-64@2.0.11:
     optional: true
 
-  turbo-windows-arm64@2.0.9:
+  turbo-windows-arm64@2.0.11:
     optional: true
 
-  turbo@2.0.9:
+  turbo@2.0.11:
     optionalDependencies:
-      turbo-darwin-64: 2.0.9
-      turbo-darwin-arm64: 2.0.9
-      turbo-linux-64: 2.0.9
-      turbo-linux-arm64: 2.0.9
-      turbo-windows-64: 2.0.9
-      turbo-windows-arm64: 2.0.9
+      turbo-darwin-64: 2.0.11
+      turbo-darwin-arm64: 2.0.11
+      turbo-linux-64: 2.0.11
+      turbo-linux-arm64: 2.0.11
+      turbo-windows-64: 2.0.11
+      turbo-windows-arm64: 2.0.11
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
## Description

* Updates turbo
* Introduces removeUserFromOrganization
* remove NON_ACTIVE status
* inviteUsers now return true if everything is ok or `InviteUsersErrors`. In order to capture this on the relevant .graphql file you need have something similar to
```
mutation inviteUsers {
  inviteUsers(role: ORG_MEMBER, emails: ["asdfads@asdfasd.asdfa"]){
    ... on MutationInviteUsersSuccess{
      data
    }
    ... on InviteUsersErrors {
      message
      errors {
        email
        message
      }
    }
  }
}
```