### PR TITLE
feat: create tiers in organizations

### DIFF
--- a/apps/backoffice/src/graphql/generated/schema-server.ts
+++ b/apps/backoffice/src/graphql/generated/schema-server.ts
@@ -830,6 +830,13 @@ export type Subscription = {
   channelInitialSetupProgress: ChannelInitialProgressPayload;
 };
 
+export enum Tier {
+  Launch = 'Launch',
+  Build = 'Build',
+  Grow = 'Grow',
+  Scale = 'Scale',
+}
+
 export type TokenDto = {
   __typename: 'TokenDto';
   refreshToken: Scalars['String']['output'];
@@ -897,13 +904,6 @@ export type ZodFieldError = {
   message: Scalars['String']['output'];
   path: Array<Scalars['String']['output']>;
 };
-
-export enum Tier {
-  Launch = 'Launch',
-  Build = 'Build',
-  Grow = 'Grow',
-  Scale = 'Scale',
-}
 
 export type GetOrganizationsQueryVariables = Exact<{ [key: string]: never }>;
 

--- a/apps/backoffice/src/graphql/generated/schema-server.ts
+++ b/apps/backoffice/src/graphql/generated/schema-server.ts
@@ -712,6 +712,7 @@ export type Organization = {
   isRoot: Scalars['Boolean']['output'];
   name: Scalars['String']['output'];
   parentId?: Maybe<Scalars['String']['output']>;
+  tier: Tier;
   updatedAt: Scalars['Date']['output'];
   userOrganizations: Array<UserOrganization>;
 };
@@ -896,6 +897,13 @@ export type ZodFieldError = {
   message: Scalars['String']['output'];
   path: Array<Scalars['String']['output']>;
 };
+
+export enum Tier {
+  Launch = 'Launch',
+  Build = 'Build',
+  Grow = 'Grow',
+  Scale = 'Scale',
+}
 
 export type GetOrganizationsQueryVariables = Exact<{ [key: string]: never }>;
 

--- a/apps/server/src/schema/generated/schema.graphql
+++ b/apps/server/src/schema/generated/schema.graphql
@@ -616,7 +616,7 @@ type Organization {
   isRoot: Boolean!
   name: String!
   parentId: String
-  tier: tier!
+  tier: Tier!
   updatedAt: Date!
   userOrganizations: [UserOrganization!]!
 }
@@ -714,6 +714,13 @@ type Subscription {
   channelInitialSetupProgress: ChannelInitialProgressPayload!
 }
 
+enum Tier {
+  Launch
+  Build
+  Grow
+  Scale
+}
+
 type TokenDto {
   refreshToken: String!
   token: String!
@@ -791,11 +798,4 @@ type ZodError implements Error {
 type ZodFieldError {
   message: String!
   path: [String!]!
-}
-
-enum tier {
-  Launch
-  Build
-  Grow
-  Scale
 }

--- a/apps/server/src/schema/generated/schema.graphql
+++ b/apps/server/src/schema/generated/schema.graphql
@@ -616,6 +616,7 @@ type Organization {
   isRoot: Boolean!
   name: String!
   parentId: String
+  tier: tier!
   updatedAt: Date!
   userOrganizations: [UserOrganization!]!
 }
@@ -790,4 +791,11 @@ type ZodError implements Error {
 type ZodFieldError {
   message: String!
   path: [String!]!
+}
+
+enum tier {
+  Launch
+  Build
+  Grow
+  Scale
 }

--- a/apps/server/src/schema/organization/org-types.ts
+++ b/apps/server/src/schema/organization/org-types.ts
@@ -81,7 +81,7 @@ export const InviteUsersErrorsDto = builder.objectType(InviteUsersErrors, {
   }),
 });
 
-export const inviteLinkDto = builder.simpleObject('InviteLinks', {
+export const InviteLinkDto = builder.simpleObject('InviteLinks', {
   fields: (t) => ({
     url: t.string({ nullable: false }),
     role: t.field({ type: OrganizationRoleEnumDto, nullable: false }),

--- a/apps/server/src/schema/organization/org-types.ts
+++ b/apps/server/src/schema/organization/org-types.ts
@@ -21,6 +21,11 @@ export const OrganizationDto = builder.prismaObject('Organization', {
     userOrganizations: t.relation('users', { nullable: false }),
     integrations: t.relation('integrations', { nullable: false }),
     adAccounts: t.relation('adAccounts', { nullable: false }),
+    tier: t.field({
+      type: tierEnum,
+      nullable: false,
+      resolve: (organization) => organization.tier,
+    }),
     isRoot: t.boolean({
       nullable: false,
       resolve: (root, _args, _ctx) => root.parentId === null,
@@ -85,4 +90,13 @@ export const inviteLinkDto = builder.simpleObject('InviteLinks', {
     url: t.string({ nullable: false }),
     role: t.field({ type: OrganizationRoleEnumDto, nullable: false }),
   }),
+});
+
+export const tierEnum = builder.enumType('tier', {
+  values: {
+    Launch: { value: 'Launch' },
+    Build: { value: 'Build' },
+    Grow: { value: 'Grow' },
+    Scale: { value: 'Scale' },
+  },
 });

--- a/apps/server/src/schema/organization/org-types.ts
+++ b/apps/server/src/schema/organization/org-types.ts
@@ -1,4 +1,4 @@
-import { OrganizationRoleEnum, UserOrganizationStatus } from '@repo/database';
+import { OrganizationRoleEnum, Tier, UserOrganizationStatus } from '@repo/database';
 import { AError } from '@repo/utils';
 import { builder } from '../builder';
 import { ErrorInterface } from '../errors';
@@ -21,11 +21,7 @@ export const OrganizationDto = builder.prismaObject('Organization', {
     userOrganizations: t.relation('users', { nullable: false }),
     integrations: t.relation('integrations', { nullable: false }),
     adAccounts: t.relation('adAccounts', { nullable: false }),
-    tier: t.field({
-      type: tierEnum,
-      nullable: false,
-      resolve: (organization) => organization.tier,
-    }),
+    tier: t.expose('tier', { type: TierEnum, nullable: false }),
     isRoot: t.boolean({
       nullable: false,
       resolve: (root, _args, _ctx) => root.parentId === null,
@@ -92,11 +88,4 @@ export const inviteLinkDto = builder.simpleObject('InviteLinks', {
   }),
 });
 
-export const tierEnum = builder.enumType('tier', {
-  values: {
-    Launch: { value: 'Launch' },
-    Build: { value: 'Build' },
-    Grow: { value: 'Grow' },
-    Scale: { value: 'Scale' },
-  },
-});
+export const TierEnum = builder.enumType(Tier, { name: 'Tier' });

--- a/apps/server/src/schema/user/invite-operations.ts
+++ b/apps/server/src/schema/user/invite-operations.ts
@@ -21,7 +21,7 @@ import {
   setConfirmInvitedUserRedis,
 } from '../../contexts/user/user-invite';
 import { userWithRoles } from '../../contexts/user/user-roles';
-import { inviteLinkDto, InviteUsersErrors, OrganizationRoleEnumDto } from '../organization/org-types';
+import { InviteLinkDto, InviteUsersErrors, OrganizationRoleEnumDto } from '../organization/org-types';
 import { env } from '../../config';
 import { sendOrganizationInviteConfirmEmail } from '../../email';
 import { validateEmail } from '../../emailable-helper';
@@ -48,7 +48,7 @@ builder.queryFields((t) => ({
   }),
 
   inviteLinks: t.withAuth({ isInOrg: true, isOrgOperator: true }).field({
-    type: [inviteLinkDto],
+    type: [InviteLinkDto],
     nullable: false,
     description: 'Returns the invitation links for the signed in org',
     resolve: async (_root, _args, ctx, _info) => {

--- a/apps/web/src/graphql/generated/schema-server.ts
+++ b/apps/web/src/graphql/generated/schema-server.ts
@@ -712,6 +712,7 @@ export type Organization = {
   isRoot: Scalars['Boolean']['output'];
   name: Scalars['String']['output'];
   parentId?: Maybe<Scalars['String']['output']>;
+  tier: Tier;
   updatedAt: Scalars['Date']['output'];
   userOrganizations: Array<UserOrganization>;
 };
@@ -896,6 +897,13 @@ export type ZodFieldError = {
   message: Scalars['String']['output'];
   path: Array<Scalars['String']['output']>;
 };
+
+export enum Tier {
+  Launch = 'Launch',
+  Build = 'Build',
+  Grow = 'Grow',
+  Scale = 'Scale',
+}
 
 export type AdAccountsQueryVariables = Exact<{ [key: string]: never }>;
 

--- a/apps/web/src/graphql/generated/schema-server.ts
+++ b/apps/web/src/graphql/generated/schema-server.ts
@@ -830,6 +830,13 @@ export type Subscription = {
   channelInitialSetupProgress: ChannelInitialProgressPayload;
 };
 
+export enum Tier {
+  Launch = 'Launch',
+  Build = 'Build',
+  Grow = 'Grow',
+  Scale = 'Scale',
+}
+
 export type TokenDto = {
   __typename: 'TokenDto';
   refreshToken: Scalars['String']['output'];
@@ -897,13 +904,6 @@ export type ZodFieldError = {
   message: Scalars['String']['output'];
   path: Array<Scalars['String']['output']>;
 };
-
-export enum Tier {
-  Launch = 'Launch',
-  Build = 'Build',
-  Grow = 'Grow',
-  Scale = 'Scale',
-}
 
 export type AdAccountsQueryVariables = Exact<{ [key: string]: never }>;
 

--- a/packages/database/prisma/migrations/20240903172348_tier/migration.sql
+++ b/packages/database/prisma/migrations/20240903172348_tier/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "Tier" AS ENUM ('Launch', 'Build', 'Grow', 'Scale');
+
+-- AlterTable
+ALTER TABLE "organizations" ADD COLUMN     "tier" "Tier" NOT NULL DEFAULT 'Launch';

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -20,6 +20,13 @@ generator pothos {
   provider = "prisma-pothos-types"
 }
 
+enum Tier {
+  Launch
+  Build
+  Grow
+  Scale
+}
+
 model Organization {
   id           String   @id @default(cuid())
   name         String
@@ -28,6 +35,7 @@ model Organization {
   randomString String   @default(cuid())
   domain       String?  @unique
   parentId     String?  @map("parent_id")
+  tier         Tier     @default(Launch)
 
   integrations    Integration[]
   users           UserOrganization[]


### PR DESCRIPTION
## Description
<!-- What does it do? -->
- Each organization should have a tier enum, that should be mandatory. The name of the tiers should match the names in our landing page. The default value been the Launch tier. The tier should be exposed through graphQL

Closes #493 
