### PR TITLE
717 groupby position yield wrong results

### DIFF
--- a/apps/web/src/app/(authenticated)/insights/components/order-filters.tsx
+++ b/apps/web/src/app/(authenticated)/insights/components/order-filters.tsx
@@ -19,6 +19,7 @@ import { InsightsColumnsGroupBy, InsightsColumnsOrderBy, InsightsInterval } from
 import { hasNextInsightsPageAtom, insightsAtom } from '@/app/atoms/insights-atoms';
 import { getOrderByValue } from '@/util/insights-utils';
 import Search from '@/components/search/search';
+import { convertFromUTC } from '@/util/mantine-utils';
 
 export default function OrderFilters(): React.ReactNode {
   const t = useTranslations('insights');
@@ -122,8 +123,8 @@ export default function OrderFilters(): React.ReactNode {
     // Perform new fetching only if both dates are given
     if (dateFrom && dateTo) {
       resetInsights();
-      newParams.set(urlKeys.dateFrom, String(getTodayStartOfDay(dateFrom).getTime()));
-      newParams.set(urlKeys.dateTo, String(getTodayStartOfDay(dateTo).getTime()));
+      newParams.set(urlKeys.dateFrom, String(getTodayStartOfDay(convertFromUTC(dateFrom)).getTime()));
+      newParams.set(urlKeys.dateTo, String(getTodayStartOfDay(convertFromUTC(dateTo)).getTime()));
       const newURL = `${pathname}?${newParams.toString()}`;
       startTransition(() => {
         router.replace(newURL);
@@ -273,7 +274,7 @@ export default function OrderFilters(): React.ReactNode {
               <DatePickerInput
                 mt="auto"
                 type="range"
-                maxDate={getTodayStartOfDay(new Date())}
+                maxDate={getTodayStartOfDay(convertFromUTC(new Date()))}
                 placeholder={tGeneric('pickDateRange')}
                 leftSection={<IconCalendarMonth />}
                 clearable

--- a/apps/web/src/app/(authenticated)/summary/components/chart-filters.tsx
+++ b/apps/web/src/app/(authenticated)/summary/components/chart-filters.tsx
@@ -17,6 +17,7 @@ import {
 import Search from '@/components/search/search';
 import { type InsightsQuery } from '@/graphql/generated/schema-server';
 import { type MultiSelectDataType } from '@/util/types';
+import { convertFromUTC } from '@/util/mantine-utils';
 
 interface PropsType {
   isPending: boolean;
@@ -60,8 +61,8 @@ export default function ChartFilters(props: PropsType): React.ReactNode {
     props.setDateRangeValue([dateFrom, dateTo]);
     // Perform new fetching only if both dates are given
     if (dateFrom && dateTo) {
-      newParams.set(urlKeys.dateFrom, String(getTodayStartOfDay(dateFrom).getTime()));
-      newParams.set(urlKeys.dateTo, String(getTodayStartOfDay(dateTo).getTime()));
+      newParams.set(urlKeys.dateFrom, String(getTodayStartOfDay(convertFromUTC(dateFrom)).getTime()));
+      newParams.set(urlKeys.dateTo, String(getTodayStartOfDay(convertFromUTC(dateTo)).getTime()));
       const newURL = `${pathname}?${newParams.toString()}`;
       startTransition(() => {
         router.replace(newURL);
@@ -147,7 +148,7 @@ export default function ChartFilters(props: PropsType): React.ReactNode {
           disabled={props.isPending}
           ml="auto"
           type="range"
-          maxDate={getTodayStartOfDay(new Date())}
+          maxDate={getTodayStartOfDay(convertFromUTC(new Date()))}
           placeholder={tGeneric('pickDateRange')}
           leftSection={<IconCalendarMonth />}
           clearable={false}

--- a/apps/web/src/util/mantine-utils.ts
+++ b/apps/web/src/util/mantine-utils.ts
@@ -1,0 +1,8 @@
+import { type DateValue } from '@mantine/dates';
+
+export const convertFromUTC = (date: DateValue): DateValue => {
+  if (!date) return null;
+  const localDate = new Date(date);
+  localDate.setMinutes(localDate.getMinutes() - localDate.getTimezoneOffset());
+  return localDate;
+};

--- a/packages/channel/src/insights-query-builder.ts
+++ b/packages/channel/src/insights-query-builder.ts
@@ -344,7 +344,7 @@ export const groupedInsights = (
   ${joinFn(snakeGroup, 'order_column_trend', 'i')}
   ${args.minThreshold || args.maxThreshold ? joinFn(snakeGroup, 'threshold_column', 'i') : ''}
   WHERE i.date >= DATE_TRUNC('${args.interval}', ${date} - INTERVAL '${dateInterval}')
-    AND i.date <= DATE_TRUNC('${args.interval}', ${date})
+    AND i.date <= ${date}
   GROUP BY ${snakeGroup.map((g) => `i.${g}`).join(', ')}, interval_start, oct.trend
   ORDER BY oct.trend${args.order === 'desc' ? ' DESC' : ''}, interval_start;`;
 

--- a/packages/channel/test/insights-query-builder.test.ts
+++ b/packages/channel/test/insights-query-builder.test.ts
@@ -574,7 +574,7 @@ void describe('insights query builder tests', () => {
   FROM organization_insights i
   JOIN order_column_trend oct ON i.ad_id = oct.ad_id AND i.publisher = oct.publisher AND i.currency = oct.currency
   WHERE i.date >= DATE_TRUNC('week', CURRENT_DATE - INTERVAL '2 week')
-    AND i.date <= DATE_TRUNC('week', CURRENT_DATE)
+    AND i.date <= CURRENT_DATE
   GROUP BY i.ad_id, i.publisher, i.currency, interval_start, oct.trend
   ORDER BY oct.trend, interval_start;`,
     );
@@ -612,7 +612,7 @@ void describe('insights query builder tests', () => {
   FROM organization_insights i
   JOIN order_column_trend oct ON i.ad_id = oct.ad_id AND i.publisher = oct.publisher AND i.currency = oct.currency
   WHERE i.date >= DATE_TRUNC('week', CURRENT_DATE - INTERVAL '2 week')
-    AND i.date <= DATE_TRUNC('week', CURRENT_DATE)
+    AND i.date <= CURRENT_DATE
   GROUP BY i.ad_id, i.publisher, i.currency, interval_start, oct.trend
   ORDER BY oct.trend DESC, interval_start;`,
     );
@@ -660,7 +660,7 @@ void describe('insights query builder tests', () => {
                 JOIN order_column_trend oct ON i.ad_id = oct.ad_id AND i.publisher = oct.publisher AND i.currency = oct.currency
                 JOIN threshold_column tc ON i.ad_id = tc.ad_id AND i.publisher = tc.publisher AND i.currency = tc.currency
        WHERE i.date >= DATE_TRUNC('week', CURRENT_DATE - INTERVAL '2 week')
-         AND i.date <= DATE_TRUNC('week', CURRENT_DATE)
+         AND i.date <= CURRENT_DATE
        GROUP BY i.ad_id, i.publisher, i.currency, interval_start, oct.trend
        ORDER BY oct.trend DESC, interval_start;`,
     );
@@ -711,7 +711,7 @@ void describe('insights query builder tests', () => {
   FROM organization_insights i
   JOIN order_column_trend oct ON i.ad_id = oct.ad_id AND i.publisher = oct.publisher AND i.currency = oct.currency
   WHERE i.date >= DATE_TRUNC('week', TIMESTAMP '2024-05-28T00:00:00.000Z' - INTERVAL '9 week')
-    AND i.date <= DATE_TRUNC('week', TIMESTAMP '2024-05-28T00:00:00.000Z')
+    AND i.date <= TIMESTAMP '2024-05-28T00:00:00.000Z'
   GROUP BY i.ad_id, i.publisher, i.currency, interval_start, oct.trend
   ORDER BY oct.trend DESC, interval_start;`,
     );
@@ -762,7 +762,7 @@ void describe('insights query builder tests', () => {
   FROM organization_insights i
   JOIN order_column_trend oct ON i.publisher = oct.publisher AND i.currency = oct.currency
   WHERE i.date >= DATE_TRUNC('day', TIMESTAMP '2024-09-30T00:00:00.000Z' - INTERVAL '4 day')
-    AND i.date <= DATE_TRUNC('day', TIMESTAMP '2024-09-30T00:00:00.000Z')
+    AND i.date <= TIMESTAMP '2024-09-30T00:00:00.000Z'
   GROUP BY i.publisher, i.currency, interval_start, oct.trend
   ORDER BY oct.trend DESC, interval_start;`,
     );
@@ -814,7 +814,7 @@ void describe('insights query builder tests', () => {
   FROM organization_insights i
   JOIN order_column_trend oct ON i.ad_id = oct.ad_id AND i.publisher = oct.publisher AND i.currency = oct.currency
   WHERE i.date >= DATE_TRUNC('week', TIMESTAMP '2024-09-30T00:00:00.000Z' - INTERVAL '1 week')
-    AND i.date <= DATE_TRUNC('week', TIMESTAMP '2024-09-30T00:00:00.000Z')
+    AND i.date <= TIMESTAMP '2024-09-30T00:00:00.000Z'
   GROUP BY i.ad_id, i.publisher, i.currency, interval_start, oct.trend
   ORDER BY oct.trend DESC, interval_start;`,
     );
@@ -857,7 +857,7 @@ void describe('insights query builder tests', () => {
   FROM organization_insights i
   JOIN order_column_trend oct ON i.ad_id = oct.ad_id AND i.publisher = oct.publisher AND i.currency = oct.currency
   WHERE i.date >= DATE_TRUNC('week', TIMESTAMP '2024-09-29T00:00:00.000Z' - INTERVAL '1 week')
-    AND i.date <= DATE_TRUNC('week', TIMESTAMP '2024-09-29T00:00:00.000Z')
+    AND i.date <= TIMESTAMP '2024-09-29T00:00:00.000Z'
   GROUP BY i.ad_id, i.publisher, i.currency, interval_start, oct.trend
   ORDER BY oct.trend DESC, interval_start;`,
     );
@@ -909,7 +909,7 @@ void describe('insights query builder tests', () => {
   FROM organization_insights i
   JOIN order_column_trend oct ON i.ad_id = oct.ad_id AND i.publisher = oct.publisher AND i.integration = oct.integration AND i.currency = oct.currency
   WHERE i.date >= DATE_TRUNC('week', TIMESTAMP '2024-05-28T00:00:00.000Z' - INTERVAL '9 week')
-    AND i.date <= DATE_TRUNC('week', TIMESTAMP '2024-05-28T00:00:00.000Z')
+    AND i.date <= TIMESTAMP '2024-05-28T00:00:00.000Z'
   GROUP BY i.ad_id, i.publisher, i.integration, i.currency, interval_start, oct.trend
   ORDER BY oct.trend DESC, interval_start;`,
     );


### PR DESCRIPTION
## Description

Lefteri as part of this issue, I fixed a bug on the web. I noticed that if you select dates and then copy paste the url, the date range was -1. This was because mantine datepicker does not take into account timezone. So it was setting hours to 0, while being gmt +2, which is the previsou day 22:00 in gmt. 